### PR TITLE
Updated Service Check to send constant tags

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -448,7 +448,23 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     the service check object
      */
     @Override public void recordServiceCheckRun(ServiceCheck sc) {
-        send(sc.toStatsDString());
+        send(toStatsDString(sc));
+    }
+    
+    private String toStatsDString(ServiceCheck sc) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("_sc|%s|%d", sc.getName(), sc.getStatus()));
+        if (sc.getTimestamp() > 0) {
+            sb.append(String.format("|d:%d", sc.getTimestamp()));
+        }
+        if (sc.getHostname() != null) {
+            sb.append(String.format("|h:%s", sc.getHostname()));
+        }
+        sb.append(tagString(sc.getTags()));
+        if (sc.getMessage() != null) {
+            sb.append(String.format("|m:%s", sc.getEscapedMessage()));
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/ServiceCheck.java
+++ b/src/main/java/com/timgroup/statsd/ServiceCheck.java
@@ -132,28 +132,4 @@ public class ServiceCheck {
     public void setTags(String... tags) {
         this.tags = tags;
     }
-
-    /**
-     * @return
-     */
-    public String toStatsDString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("_sc|%s|%d", name, status));
-        if (timestamp > 0) {
-            sb.append(String.format("|d:%d", timestamp));
-        }
-        if (hostname != null) {
-            sb.append(String.format("|h:%s", hostname));
-        }
-        if (tags != null && tags.length > 0) {
-            sb.append(String.format("|#%s", tags[0]));
-            for(int i=1;i<tags.length;i++) {
-                sb.append(',').append(tags[i]);
-            }
-        }
-        if (message != null) {
-            sb.append(String.format("|m:%s", this.getEscapedMessage()));
-        }
-        return sb.toString();
-    }
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -303,7 +303,7 @@ public class NonBlockingStatsDClientTest {
         client.serviceCheck(sc);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key1:val1,key2:val2|m:%s",
+        assertThat(server.messagesReceived(), contains(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s",
                 "♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")));
     }
 }


### PR DESCRIPTION
The ServiceCheck class doesn't reuse the tag serialization code within the Client which causes constance tags set on the client to not be included in the message. This moves the logic into the client and reuses the method that writes the messages and constant tags.