### PR TITLE
Use ThreadLocalRandom vs Math.random

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-  - openjdk6
 
 install: mvn install -DskipTests -Dgpg.skip

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 
@@ -841,7 +842,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
     
     private boolean isInvalidSample(double sampleRate) {
-    	return sampleRate != 1 && Math.random() > sampleRate;
+        return sampleRate != 1 && ThreadLocalRandom.current().nextDouble() > sampleRate;
     }
 
     public static final Charset MESSAGE_CHARSET = Charset.forName("UTF-8");


### PR DESCRIPTION
There is an atomic compare and set loop in `Math.random` that can cause performance issues.

You can find many postings on the performance aspects of this change
http://blog.anvard.org/articles/2014/01/12/concurrent-random.html

This change requires a minimum version change from Java 1.6 to 1.7
