### PR TITLE
Reducing buffer size to 1400

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  */
 public final class NonBlockingStatsDClient implements StatsDClient {
 
-    private static final int PACKET_SIZE_BYTES = 1500;
+    private static final int PACKET_SIZE_BYTES = 1400;
 
     private static final StatsDClientErrorHandler NO_OP_HANDLER = new StatsDClientErrorHandler() {
         @Override public void handle(final Exception e) { /* No-op */ }


### PR DESCRIPTION
Were using the NonBlockingStatsDClient to push to a statsD_exporter endpoint that prometheus picks up from. 
We've noticed that we were dropping a lot of data, although we were sending it correctly. 
Looking into it it seemed to be that the size of the packets was too big. 

Given how the message buffer gets filled up; in the case where it was getting close to the 1500 mark, the addition of the ethernet/udp headers was pushing it past the MTU size causing fragmentation. 