### PR TITLE
Blocking client

### DIFF
--- a/src/main/java/com/timgroup/statsd/AbstractDatagramStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/AbstractDatagramStatsDClient.java
@@ -1,0 +1,104 @@
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.concurrent.Callable;
+
+abstract class AbstractDatagramStatsDClient extends AbstractStatsDClient {
+
+    private final DatagramChannel clientChannel;
+    private final Callable<InetSocketAddress> addressLookup;
+
+    /**
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    AbstractDatagramStatsDClient(String prefix, String[] constantTags, StatsDClientErrorHandler errorHandler, Callable<InetSocketAddress> addressLookup) throws StatsDClientException {
+        super(prefix, constantTags);
+
+        this.addressLookup = addressLookup;
+        try {
+            clientChannel = DatagramChannel.open();
+        } catch (final Exception e) {
+            throw new StatsDClientException("Failed to start StatsD client", e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        try {
+            clientChannel.close();
+        } catch (IOException e) {
+            throw new StatsDClientException("Unable to close client", e);
+        }
+    }
+
+    void sendBlocking(ByteBuffer sendBuffer) throws Exception {
+        int sizeOfBuffer = sendBuffer.limit();
+        InetSocketAddress address = addressLookup.call();
+        int sentBytes = clientChannel.send(sendBuffer, address);
+        if (sizeOfBuffer != sentBytes) {
+            throw new IOException(
+                    String.format(
+                            "Could not send entirely stat %s to host %s. Only sent %d bytes out of %d bytes",
+                            sendBuffer.toString(),
+                            address.toString(),
+                            sentBytes,
+                            sizeOfBuffer));
+        }
+    }
+
+    /**
+     * Create dynamic lookup for the given host name and port.
+     *
+     * @param hostname the host name of the targeted StatsD server
+     * @param port     the port of the targeted StatsD server
+     * @return a function to perform the lookup
+     */
+    public static Callable<InetSocketAddress> volatileAddressResolution(final String hostname, final int port) {
+        return new Callable<InetSocketAddress>() {
+            @Override
+            public InetSocketAddress call() throws UnknownHostException {
+                return new InetSocketAddress(InetAddress.getByName(hostname), port);
+            }
+        };
+    }
+
+    /**
+     * Lookup the address for the given host name and cache the result.
+     *
+     * @param hostname the host name of the targeted StatsD server
+     * @param port     the port of the targeted StatsD server
+     * @return a function that cached the result of the lookup
+     * @throws Exception if the lookup fails, i.e. {@link UnknownHostException}
+     */
+    public static Callable<InetSocketAddress> staticAddressResolution(final String hostname, final int port) throws Exception {
+        final InetSocketAddress address = volatileAddressResolution(hostname, port).call();
+        return new Callable<InetSocketAddress>() {
+            @Override
+            public InetSocketAddress call() {
+                return address;
+            }
+        };
+    }
+
+    protected static Callable<InetSocketAddress> staticStatsDAddressResolution(final String hostname, final int port) throws StatsDClientException {
+        try {
+            return staticAddressResolution(hostname, port);
+        } catch (final Exception e) {
+            throw new StatsDClientException("Failed to lookup StatsD host", e);
+        }
+    }
+}

--- a/src/main/java/com/timgroup/statsd/AbstractStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/AbstractStatsDClient.java
@@ -1,0 +1,467 @@
+package com.timgroup.statsd;
+
+import java.nio.charset.Charset;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+abstract class AbstractStatsDClient implements StatsDClient {
+
+    private static final Charset MESSAGE_CHARSET = Charset.forName("UTF-8");
+
+    /**
+     * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
+     * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
+     * http://stackoverflow.com/a/1285297/2648
+     * https://github.com/indeedeng/java-dogstatsd-client/issues/4
+     */
+    private static final ThreadLocal<NumberFormat> NUMBER_FORMATTERS = new ThreadLocal<NumberFormat>() {
+        @Override
+        protected NumberFormat initialValue() {
+
+            // Always create the formatter for the US locale in order to avoid this bug:
+            // https://github.com/indeedeng/java-dogstatsd-client/issues/3
+            final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
+            numberFormatter.setGroupingUsed(false);
+            numberFormatter.setMaximumFractionDigits(6);
+
+            // we need to specify a value for Double.NaN that is recognized by dogStatsD
+            if (numberFormatter instanceof DecimalFormat) { // better safe than a runtime error
+                final DecimalFormat decimalFormat = (DecimalFormat) numberFormatter;
+                final DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
+                symbols.setNaN("NaN");
+                decimalFormat.setDecimalFormatSymbols(symbols);
+            }
+
+            return numberFormatter;
+        }
+    };
+
+    private final String prefix;
+    private final String constantTagsRendered;
+
+    /**
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     */
+    AbstractStatsDClient(final String prefix, String[] constantTags) throws StatsDClientException {
+        if((prefix != null) && (!prefix.isEmpty())) {
+            this.prefix = String.format("%s.", prefix);
+        } else {
+            this.prefix = "";
+        }
+
+        /* Empty list should be null for faster comparison */
+        if((constantTags != null) && (constantTags.length == 0)) {
+            constantTags = null;
+        }
+
+        if(constantTags != null) {
+            constantTagsRendered = tagString(constantTags, null);
+        } else {
+            constantTagsRendered = null;
+        }
+    }
+
+    /**
+     * Generate a suffix conveying the given tag list to the client
+     */
+    private static String tagString(final String[] tags, final String tagPrefix) {
+        final StringBuilder sb;
+        if(tagPrefix != null) {
+            if((tags == null) || (tags.length == 0)) {
+                return tagPrefix;
+            }
+            sb = new StringBuilder(tagPrefix);
+            sb.append(",");
+        } else {
+            if((tags == null) || (tags.length == 0)) {
+                return "";
+            }
+            sb = new StringBuilder("|#");
+        }
+
+        for(int n=tags.length - 1; n>=0; n--) {
+            sb.append(tags[n]);
+            if(n > 0) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Generate a suffix conveying the given tag list to the client
+     */
+    private String tagString(final String[] tags) {
+        return tagString(tags, constantTagsRendered);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void count(final String aspect, final long delta, final String... tags) {
+        send(String.format("%s%s:%d|c%s", prefix, aspect, delta, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void count(final String aspect, final long delta, final double sampleRate, final String...tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+    	send(String.format("%s%s:%d|c|@%f%s", prefix, aspect, delta, sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void incrementCounter(final String aspect, final String... tags) {
+        count(aspect, 1, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void incrementCounter(final String aspect, final double sampleRate, final String... tags) {
+    	count(aspect, 1, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void increment(final String aspect, final String... tags) {
+        incrementCounter(aspect, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void increment(final String aspect, final double sampleRate, final String...tags ) {
+    	incrementCounter(aspect, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void decrementCounter(final String aspect, final String... tags) {
+        count(aspect, -1, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void decrementCounter(String aspect, final double sampleRate, final String... tags) {
+        count(aspect, -1, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void decrement(final String aspect, final String... tags) {
+        decrementCounter(aspect, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void decrement(final String aspect, final double sampleRate, final String... tags) {
+        decrementCounter(aspect, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordGaugeValue(final String aspect, final double value, final String... tags) {
+        /* Intentionally using %s rather than %f here to avoid
+         * padding with extra 0s to represent precision */
+        send(String.format("%s%s:%s|g%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordGaugeValue(final String aspect, final double value, final double sampleRate, final String... tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+        send(String.format("%s%s:%s|g|@%f%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void gauge(final String aspect, final double value, final String... tags) {
+        recordGaugeValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void gauge(final String aspect, final double value, final double sampleRate, final String... tags) {
+        recordGaugeValue(aspect, value, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordGaugeValue(final String aspect, final long value, final String... tags) {
+        send(String.format("%s%s:%d|g%s", prefix, aspect, value, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordGaugeValue(final String aspect, final long value, final double sampleRate, final String... tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+        send(String.format("%s%s:%d|g|@%f%s", prefix, aspect, value, sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void gauge(final String aspect, final long value, final String... tags) {
+        recordGaugeValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void gauge(final String aspect, final long value, final double sampleRate, final String... tags) {
+        recordGaugeValue(aspect, value, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordExecutionTime(final String aspect, final long timeInMs, final String... tags) {
+        send(String.format("%s%s:%d|ms%s", prefix, aspect, timeInMs, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordExecutionTime(final String aspect, final long timeInMs, final double sampleRate, final String... tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+        send(String.format("%s%s:%d|ms|@%f%s", prefix, aspect, timeInMs, sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void time(final String aspect, final long value, final String... tags) {
+        recordExecutionTime(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void time(final String aspect, final long value, final double sampleRate, final String... tags) {
+        recordExecutionTime(aspect, value, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordHistogramValue(final String aspect, final double value, final String... tags) {
+        /* Intentionally using %s rather than %f here to avoid
+         * padding with extra 0s to represent precision */
+        send(String.format("%s%s:%s|h%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordHistogramValue(final String aspect, final double value, final double sampleRate, final String... tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+    	  /* Intentionally using %s rather than %f here to avoid
+    	   * padding with extra 0s to represent precision */
+    	send(String.format("%s%s:%s|h|@%f%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void histogram(final String aspect, final double value, final String... tags) {
+        recordHistogramValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void histogram(final String aspect, final double value, final double sampleRate, final String... tags) {
+        recordHistogramValue(aspect, value, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordHistogramValue(final String aspect, final long value, final String... tags) {
+        send(String.format("%s%s:%d|h%s", prefix, aspect, value, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordHistogramValue(final String aspect, final long value, final double sampleRate, final String... tags) {
+    	if(isInvalidSample(sampleRate)) {
+    		return;
+    	}
+        send(String.format("%s%s:%d|h|@%f%s", prefix, aspect, value, sampleRate, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void histogram(final String aspect, final long value, final String... tags) {
+        recordHistogramValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void histogram(final String aspect, final long value, final double sampleRate, final String... tags) {
+        recordHistogramValue(aspect, value, sampleRate, tags);
+    }
+
+    private String eventMap(final Event event) {
+        final StringBuilder res = new StringBuilder("");
+
+        final long millisSinceEpoch = event.getMillisSinceEpoch();
+        if (millisSinceEpoch != -1) {
+            res.append("|d:").append(millisSinceEpoch / 1000);
+        }
+
+        final String hostname = event.getHostname();
+        if (hostname != null) {
+            res.append("|h:").append(hostname);
+        }
+
+        final String aggregationKey = event.getAggregationKey();
+        if (aggregationKey != null) {
+            res.append("|k:").append(aggregationKey);
+        }
+
+        final String priority = event.getPriority();
+        if (priority != null) {
+            res.append("|p:").append(priority);
+        }
+
+        final String alertType = event.getAlertType();
+        if (alertType != null) {
+            res.append("|t:").append(alertType);
+        }
+
+        return res.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordEvent(final Event event, final String... tags) {
+        final String title = escapeEventString(prefix + event.getTitle());
+        final String text = escapeEventString(event.getText());
+        send(String.format("_e{%d,%d}:%s|%s%s%s",
+                title.length(), text.length(), title, text, eventMap(event), tagString(tags)));
+    }
+
+    private String escapeEventString(final String title) {
+        return title.replace("\n", "\\n");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordServiceCheckRun(final ServiceCheck sc) {
+        send(toStatsDString(sc));
+    }
+
+    private String toStatsDString(final ServiceCheck sc) {
+        // see http://docs.datadoghq.com/guides/dogstatsd/#service-checks
+        final StringBuilder sb = new StringBuilder();
+        sb.append(String.format("_sc|%s|%d", sc.getName(), sc.getStatus()));
+        if (sc.getTimestamp() > 0) {
+            sb.append(String.format("|d:%d", sc.getTimestamp()));
+        }
+        if (sc.getHostname() != null) {
+            sb.append(String.format("|h:%s", sc.getHostname()));
+        }
+        sb.append(tagString(sc.getTags()));
+        if (sc.getMessage() != null) {
+            sb.append(String.format("|m:%s", sc.getEscapedMessage()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void serviceCheck(final ServiceCheck sc) {
+        recordServiceCheckRun(sc);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void recordSetValue(final String aspect, final String value, final String... tags) {
+        // documentation is light, but looking at dogstatsd source, we can send string values
+        // here instead of numbers
+        send(String.format("%s%s:%s|s%s", prefix, aspect, value, tagString(tags)));
+    }
+
+    private void send(final String message) {
+        send(message.getBytes(MESSAGE_CHARSET));
+    }
+
+    abstract void send(final byte[] message);
+
+    private boolean isInvalidSample(double sampleRate) {
+    	return sampleRate != 1 && Math.random() > sampleRate;
+    }
+
+}

--- a/src/main/java/com/timgroup/statsd/BlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/BlockingStatsDClient.java
@@ -1,0 +1,142 @@
+package com.timgroup.statsd;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Callable;
+
+/**
+ * A simple StatsD client implementation facilitating metrics recording.
+ *
+ * <p>Upon instantiation, this client will establish a socket connection to a StatsD instance
+ * running on the specified host and port. Metrics are then sent over this connection as they are
+ * received by the client.
+ * </p>
+ *
+ * <p>Three key methods are provided for the submission of data-points for the application under
+ * scrutiny:
+ * <ul>
+ *   <li>{@link #incrementCounter} - adds one to the value of the specified named counter</li>
+ *   <li>{@link #recordGaugeValue} - records the latest fixed value for the specified named gauge</li>
+ *   <li>{@link #recordExecutionTime} - records an execution time in milliseconds for the specified named operation</li>
+ *   <li>{@link #recordHistogramValue} - records a value, to be tracked with average, maximum, and percentiles</li>
+ *   <li>{@link #recordEvent} - records an event</li>
+ *   <li>{@link #recordSetValue} - records a value in a set</li>
+ * </ul>
+ * From the perspective of the application, these methods are blocking, with the resulting
+ * IO operations being carried out in the same thread.
+ * The methods may propagate an exception which may disrupt application execution.
+ *
+ * <p>As part of a clean system shutdown, the {@link #stop()} method should be invoked
+ * on any StatsD clients.</p>
+ *
+ * @author Daniel Würsch
+ *
+ */
+public final class BlockingStatsDClient extends AbstractDatagramStatsDClient {
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. All exceptions thrown during subsequent usage are
+     * propagated and failure in metrics will affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server
+     * @param port
+     *     the port of the targeted StatsD server
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    public BlockingStatsDClient(final String prefix, final String hostname, final int port) throws StatsDClientException {
+        this(prefix, hostname, port, null, null);
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. All exceptions thrown during subsequent usage are
+     * propagated and failure in metrics will affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server
+     * @param port
+     *     the port of the targeted StatsD server
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    public BlockingStatsDClient(final String prefix, final String hostname, final int port, final String... constantTags) throws StatsDClientException {
+        this(prefix, hostname, port, constantTags, null);
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. All exceptions thrown during subsequent usage are
+     * propagated and failure in metrics will affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server
+     * @param port
+     *     the port of the targeted StatsD server
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    public BlockingStatsDClient(final String prefix, final String hostname, final int port,
+                                final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+        this(prefix, constantTags, errorHandler, staticStatsDAddressResolution(hostname, port));
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. All exceptions thrown during subsequent usage are
+     * propagated and failure in metrics will affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    public BlockingStatsDClient(final String prefix, String[] constantTags, final StatsDClientErrorHandler errorHandler,
+                                final Callable<InetSocketAddress> addressLookup) throws StatsDClientException {
+        super(prefix, constantTags, errorHandler, addressLookup);
+    }
+
+    void send(final byte[] message) {
+        try {
+            sendBlocking(ByteBuffer.wrap(message));
+        } catch (Exception e) {
+            throw new StatsDClientException("Unable to send", e);
+        }
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1,25 +1,8 @@
 package com.timgroup.statsd;
 
-import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.nio.channels.DatagramChannel;
-import java.nio.charset.Charset;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.util.Locale;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-
-
+import java.util.concurrent.*;
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
@@ -49,46 +32,13 @@ import java.util.concurrent.TimeUnit;
  * @author Tom Denley
  *
  */
-public final class NonBlockingStatsDClient implements StatsDClient {
+public final class NonBlockingStatsDClient extends AbstractDatagramStatsDClient {
 
     private static final int PACKET_SIZE_BYTES = 1400;
 
     private static final StatsDClientErrorHandler NO_OP_HANDLER = new StatsDClientErrorHandler() {
         @Override public void handle(final Exception e) { /* No-op */ }
     };
-
-    /**
-     * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
-     * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
-     * http://stackoverflow.com/a/1285297/2648
-     * https://github.com/indeedeng/java-dogstatsd-client/issues/4
-     */
-    private static final ThreadLocal<NumberFormat> NUMBER_FORMATTERS = new ThreadLocal<NumberFormat>() {
-        @Override
-        protected NumberFormat initialValue() {
-
-            // Always create the formatter for the US locale in order to avoid this bug:
-            // https://github.com/indeedeng/java-dogstatsd-client/issues/3
-            final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
-            numberFormatter.setGroupingUsed(false);
-            numberFormatter.setMaximumFractionDigits(6);
-
-            // we need to specify a value for Double.NaN that is recognized by dogStatsD
-            if (numberFormatter instanceof DecimalFormat) { // better safe than a runtime error
-                final DecimalFormat decimalFormat = (DecimalFormat) numberFormatter;
-                final DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
-                symbols.setNaN("NaN");
-                decimalFormat.setDecimalFormatSymbols(symbols);
-            }
-
-            return numberFormatter;
-        }
-    };
-
-    private final String prefix;
-    private final DatagramChannel clientChannel;
-    private final StatsDClientErrorHandler handler;
-    private final String constantTagsRendered;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
         final ThreadFactory delegate = Executors.defaultThreadFactory();
@@ -100,7 +50,8 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         }
     });
 
-    private final BlockingQueue<String> queue;
+    private final BlockingQueue<byte[]> queue;
+    private final StatsDClientErrorHandler handler;
 
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
@@ -288,36 +239,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      */
     public NonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
                                    final Callable<InetSocketAddress> addressLookup) throws StatsDClientException {
-        if((prefix != null) && (!prefix.isEmpty())) {
-            this.prefix = String.format("%s.", prefix);
-        } else {
-            this.prefix = "";
-        }
-        if(errorHandler == null) {
+        super(prefix, constantTags, errorHandler, addressLookup);
+
+        if (errorHandler == null) {
             handler = NO_OP_HANDLER;
-        }
-        else {
+        } else {
             handler = errorHandler;
         }
 
-        /* Empty list should be null for faster comparison */
-        if((constantTags != null) && (constantTags.length == 0)) {
-            constantTags = null;
-        }
-
-        if(constantTags != null) {
-            constantTagsRendered = tagString(constantTags, null);
-        } else {
-            constantTagsRendered = null;
-        }
-
-        try {
-            clientChannel = DatagramChannel.open();
-        } catch (final Exception e) {
-            throw new StatsDClientException("Failed to start StatsD client", e);
-        }
-        queue = new LinkedBlockingQueue<String>(queueSize);
-        executor.submit(new QueueConsumer(addressLookup));
+        queue = new LinkedBlockingQueue<byte[]>(queueSize);
+        executor.submit(new QueueConsumer());
     }
 
     /**
@@ -329,549 +260,35 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         try {
             executor.shutdown();
             executor.awaitTermination(30, TimeUnit.SECONDS);
-        }
-        catch (final Exception e) {
+        }  catch (final Exception e) {
             handler.handle(e);
         }
         finally {
-            if (clientChannel != null) {
-                try {
-                    clientChannel.close();
-                }
-                catch (final IOException e) {
-                    handler.handle(e);
-                }
-            }
+            super.stop();
         }
     }
 
-    /**
-     * Generate a suffix conveying the given tag list to the client
-     */
-    static String tagString(final String[] tags, final String tagPrefix) {
-        final StringBuilder sb;
-        if(tagPrefix != null) {
-            if((tags == null) || (tags.length == 0)) {
-                return tagPrefix;
-            }
-            sb = new StringBuilder(tagPrefix);
-            sb.append(",");
-        } else {
-            if((tags == null) || (tags.length == 0)) {
-                return "";
-            }
-            sb = new StringBuilder("|#");
-        }
-
-        for(int n=tags.length - 1; n>=0; n--) {
-            sb.append(tags[n]);
-            if(n > 0) {
-                sb.append(",");
-            }
-        }
-        return sb.toString();
+    void send(final byte[] data) {
+        queue.offer(data);
     }
-
-    /**
-     * Generate a suffix conveying the given tag list to the client
-     */
-    String tagString(final String[] tags) {
-        return tagString(tags, constantTagsRendered);
-    }
-
-    /**
-     * Adjusts the specified counter by a given delta.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to adjust
-     * @param delta
-     *     the amount to adjust the counter by
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void count(final String aspect, final long delta, final String... tags) {
-        send(String.format("%s%s:%d|c%s", prefix, aspect, delta, tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void count(final String aspect, final long delta, final double sampleRate, final String...tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-    	send(String.format("%s%s:%d|c|@%f%s", prefix, aspect, delta, sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Increments the specified counter by one.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to increment
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void incrementCounter(final String aspect, final String... tags) {
-        count(aspect, 1, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void incrementCounter(final String aspect, final double sampleRate, final String... tags) {
-    	count(aspect, 1, sampleRate, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #incrementCounter(String, String[])}.
-     */
-    @Override
-    public void increment(final String aspect, final String... tags) {
-        incrementCounter(aspect, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void increment(final String aspect, final double sampleRate, final String...tags ) {
-    	incrementCounter(aspect, sampleRate, tags);
-    }
-
-    /**
-     * Decrements the specified counter by one.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to decrement
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void decrementCounter(final String aspect, final String... tags) {
-        count(aspect, -1, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void decrementCounter(String aspect, final double sampleRate, final String... tags) {
-        count(aspect, -1, sampleRate, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #decrementCounter(String, String[])}.
-     */
-    @Override
-    public void decrement(final String aspect, final String... tags) {
-        decrementCounter(aspect, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void decrement(final String aspect, final double sampleRate, final String... tags) {
-        decrementCounter(aspect, sampleRate, tags);
-    }
-
-    /**
-     * Records the latest fixed value for the specified named gauge.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void recordGaugeValue(final String aspect, final double value, final String... tags) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        send(String.format("%s%s:%s|g%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordGaugeValue(final String aspect, final double value, final double sampleRate, final String... tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-        send(String.format("%s%s:%s|g|@%f%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, double, String[])}.
-     */
-    @Override
-    public void gauge(final String aspect, final double value, final String... tags) {
-        recordGaugeValue(aspect, value, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void gauge(final String aspect, final double value, final double sampleRate, final String... tags) {
-        recordGaugeValue(aspect, value, sampleRate, tags);
-    }
-
-
-    /**
-     * Records the latest fixed value for the specified named gauge.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void recordGaugeValue(final String aspect, final long value, final String... tags) {
-        send(String.format("%s%s:%d|g%s", prefix, aspect, value, tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordGaugeValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-        send(String.format("%s%s:%d|g|@%f%s", prefix, aspect, value, sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, long, String[])}.
-     */
-    @Override
-    public void gauge(final String aspect, final long value, final String... tags) {
-        recordGaugeValue(aspect, value, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void gauge(final String aspect, final long value, final double sampleRate, final String... tags) {
-        recordGaugeValue(aspect, value, sampleRate, tags);
-    }
-
-    /**
-     * Records an execution time in milliseconds for the specified named operation.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the timed operation
-     * @param timeInMs
-     *     the time in milliseconds
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void recordExecutionTime(final String aspect, final long timeInMs, final String... tags) {
-        send(String.format("%s%s:%d|ms%s", prefix, aspect, timeInMs, tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordExecutionTime(final String aspect, final long timeInMs, final double sampleRate, final String... tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-        send(String.format("%s%s:%d|ms|@%f%s", prefix, aspect, timeInMs, sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, long, String[])}.
-     */
-    @Override
-    public void time(final String aspect, final long value, final String... tags) {
-        recordExecutionTime(aspect, value, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void time(final String aspect, final long value, final double sampleRate, final String... tags) {
-        recordExecutionTime(aspect, value, sampleRate, tags);
-    }
-
-    /**
-     * Records a value for the specified named histogram.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void recordHistogramValue(final String aspect, final double value, final String... tags) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        send(String.format("%s%s:%s|h%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordHistogramValue(final String aspect, final double value, final double sampleRate, final String... tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-    	  /* Intentionally using %s rather than %f here to avoid
-    	   * padding with extra 0s to represent precision */
-    	send(String.format("%s%s:%s|h|@%f%s", prefix, aspect, NUMBER_FORMATTERS.get().format(value), sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, double, String[])}.
-     */
-    @Override
-    public void histogram(final String aspect, final double value, final String... tags) {
-        recordHistogramValue(aspect, value, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void histogram(final String aspect, final double value, final double sampleRate, final String... tags) {
-        recordHistogramValue(aspect, value, sampleRate, tags);
-    }
-
-    /**
-     * Records a value for the specified named histogram.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     * @param tags
-     *     array of tags to be added to the data
-     */
-    @Override
-    public void recordHistogramValue(final String aspect, final long value, final String... tags) {
-        send(String.format("%s%s:%d|h%s", prefix, aspect, value, tagString(tags)));
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordHistogramValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-    	if(isInvalidSample(sampleRate)) {
-    		return;
-    	}
-        send(String.format("%s%s:%d|h|@%f%s", prefix, aspect, value, sampleRate, tagString(tags)));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, long, String[])}.
-     */
-    @Override
-    public void histogram(final String aspect, final long value, final String... tags) {
-        recordHistogramValue(aspect, value, tags);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void histogram(final String aspect, final long value, final double sampleRate, final String... tags) {
-        recordHistogramValue(aspect, value, sampleRate, tags);
-    }
-
-    private String eventMap(final Event event) {
-        final StringBuilder res = new StringBuilder("");
-
-        final long millisSinceEpoch = event.getMillisSinceEpoch();
-        if (millisSinceEpoch != -1) {
-            res.append("|d:").append(millisSinceEpoch / 1000);
-        }
-
-        final String hostname = event.getHostname();
-        if (hostname != null) {
-            res.append("|h:").append(hostname);
-        }
-
-        final String aggregationKey = event.getAggregationKey();
-        if (aggregationKey != null) {
-            res.append("|k:").append(aggregationKey);
-        }
-
-        final String priority = event.getPriority();
-        if (priority != null) {
-            res.append("|p:").append(priority);
-        }
-
-        final String alertType = event.getAlertType();
-        if (alertType != null) {
-            res.append("|t:").append(alertType);
-        }
-
-        return res.toString();
-    }
-
-    /**
-     * Records an event
-     *
-     * <p>This method is a DataDog extension, and may not work with other servers.</p>
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param event
-     *     The event to record
-     * @param tags
-     *     array of tags to be added to the data
-     *
-     * @see <a href="http://docs.datadoghq.com/guides/dogstatsd/#events-1">http://docs.datadoghq.com/guides/dogstatsd/#events-1</a>
-     */
-    @Override
-    public void recordEvent(final Event event, final String... tags) {
-        final String title = escapeEventString(prefix + event.getTitle());
-        final String text = escapeEventString(event.getText());
-        send(String.format("_e{%d,%d}:%s|%s%s%s",
-                title.length(), text.length(), title, text, eventMap(event), tagString(tags)));
-    }
-
-    private String escapeEventString(final String title) {
-        return title.replace("\n", "\\n");
-    }
-
-    /**
-     * Records a run status for the specified named service check.
-     *
-     * <p>This method is a DataDog extension, and may not work with other servers.</p>
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param sc
-     *     the service check object
-     */
-    @Override
-    public void recordServiceCheckRun(final ServiceCheck sc) {
-        send(toStatsDString(sc));
-    }
-
-    private String toStatsDString(final ServiceCheck sc) {
-        // see http://docs.datadoghq.com/guides/dogstatsd/#service-checks
-        final StringBuilder sb = new StringBuilder();
-        sb.append(String.format("_sc|%s|%d", sc.getName(), sc.getStatus()));
-        if (sc.getTimestamp() > 0) {
-            sb.append(String.format("|d:%d", sc.getTimestamp()));
-        }
-        if (sc.getHostname() != null) {
-            sb.append(String.format("|h:%s", sc.getHostname()));
-        }
-        sb.append(tagString(sc.getTags()));
-        if (sc.getMessage() != null) {
-            sb.append(String.format("|m:%s", sc.getEscapedMessage()));
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordServiceCheckRun(ServiceCheck sc)}.
-     */
-    @Override
-    public void serviceCheck(final ServiceCheck sc) {
-        recordServiceCheckRun(sc);
-    }
-
-
-    /**
-     * Records a value for the specified set.
-     *
-     * Sets are used to count the number of unique elements in a group. If you want to track the number of
-     * unique visitor to your site, sets are a great way to do that.
-     *
-     * <p>This method is a DataDog extension, and may not work with other servers.</p>
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the set
-     * @param value
-     *     the value to track
-     * @param tags
-     *     array of tags to be added to the data
-     *
-     * @see <a href="http://docs.datadoghq.com/guides/dogstatsd/#sets">http://docs.datadoghq.com/guides/dogstatsd/#sets</a>
-     */
-    @Override
-    public void recordSetValue(final String aspect, final String value, final String... tags) {
-        // documentation is light, but looking at dogstatsd source, we can send string values
-        // here instead of numbers
-        send(String.format("%s%s:%s|s%s", prefix, aspect, value, tagString(tags)));
-    }
-
-    private void send(final String message) {
-        queue.offer(message);
-    }
-    
-    private boolean isInvalidSample(double sampleRate) {
-    	return sampleRate != 1 && Math.random() > sampleRate;
-    }
-
-    public static final Charset MESSAGE_CHARSET = Charset.forName("UTF-8");
-
 
     private class QueueConsumer implements Runnable {
         private final ByteBuffer sendBuffer = ByteBuffer.allocate(PACKET_SIZE_BYTES);
 
-        private final Callable<InetSocketAddress> addressLookup;
-
-        QueueConsumer(final Callable<InetSocketAddress> addressLookup) {
-            this.addressLookup = addressLookup;
-        }
-
         @Override public void run() {
             while(!executor.isShutdown()) {
                 try {
-                    final String message = queue.poll(1, TimeUnit.SECONDS);
-                    if(null != message) {
-                        final InetSocketAddress address = addressLookup.call();
-                        final byte[] data = message.getBytes(MESSAGE_CHARSET);
+                    final byte[] data = queue.poll(1, TimeUnit.SECONDS);
+                    if(null != data) {
                         if(sendBuffer.remaining() < (data.length + 1)) {
-                            blockingSend(address);
+                            blockingSend();
                         }
                         if(sendBuffer.position() > 0) {
                             sendBuffer.put( (byte) '\n');
                         }
                         sendBuffer.put(data);
                         if(null == queue.peek()) {
-                            blockingSend(address);
+                            blockingSend();
                         }
                     }
                 } catch (final Exception e) {
@@ -880,65 +297,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
             }
         }
 
-        private void blockingSend(final InetSocketAddress address) throws IOException {
-            final int sizeOfBuffer = sendBuffer.position();
+        private void blockingSend() throws Exception {
             sendBuffer.flip();
-
-            final int sentBytes = clientChannel.send(sendBuffer, address);
+            sendBlocking(sendBuffer);
             sendBuffer.limit(sendBuffer.capacity());
             sendBuffer.rewind();
-
-            if (sizeOfBuffer != sentBytes) {
-                handler.handle(
-                        new IOException(
-                            String.format(
-                                "Could not send entirely stat %s to host %s:%d. Only sent %d bytes out of %d bytes",
-                                sendBuffer.toString(),
-                                address.getHostName(),
-                                address.getPort(),
-                                sentBytes,
-                                sizeOfBuffer)));
-            }
-        }
-    }
-
-    /**
-     * Create dynamic lookup for the given host name and port.
-     *
-     * @param hostname the host name of the targeted StatsD server
-     * @param port     the port of the targeted StatsD server
-     * @return a function to perform the lookup
-     */
-    public static Callable<InetSocketAddress> volatileAddressResolution(final String hostname, final int port) {
-        return new Callable<InetSocketAddress>() {
-            @Override public InetSocketAddress call() throws UnknownHostException {
-                return new InetSocketAddress(InetAddress.getByName(hostname), port);
-            }
-        };
-    }
-
-  /**
-   * Lookup the address for the given host name and cache the result.
-   *
-   * @param hostname the host name of the targeted StatsD server
-   * @param port     the port of the targeted StatsD server
-   * @return a function that cached the result of the lookup
-   * @throws Exception if the lookup fails, i.e. {@link UnknownHostException}
-   */
-    public static Callable<InetSocketAddress> staticAddressResolution(final String hostname, final int port) throws Exception {
-        final InetSocketAddress address = volatileAddressResolution(hostname, port).call();
-        return new Callable<InetSocketAddress>() {
-            @Override public InetSocketAddress call() {
-                return address;
-            }
-        };
-    }
-
-    private static Callable<InetSocketAddress> staticStatsDAddressResolution(final String hostname, final int port) throws StatsDClientException {
-        try {
-            return staticAddressResolution(hostname, port);
-        } catch (final Exception e) {
-            throw new StatsDClientException("Failed to lookup StatsD host", e);
         }
     }
 }

--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -5,11 +5,15 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
 
 final class DummyStatsDServer {
+
+    private static final Charset MESSAGE_CHARSET = Charset.forName("UTF-8");
+
     private final List<String> messagesReceived = new ArrayList<String>();
     private final DatagramSocket server;
 
@@ -22,7 +26,7 @@ final class DummyStatsDServer {
                     try {
                         final DatagramPacket packet = new DatagramPacket(new byte[1500], 1500);
                         server.receive(packet);
-                        for(String msg : new String(packet.getData(), NonBlockingStatsDClient.MESSAGE_CHARSET).split("\n")) {
+                        for(String msg : new String(packet.getData(), MESSAGE_CHARSET).split("\n")) {
                             messagesReceived.add(msg.trim());
                         }
                     } catch (IOException e) {

--- a/src/test/java/com/timgroup/statsd/StatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDClientTest.java
@@ -1,22 +1,40 @@
 package com.timgroup.statsd;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.net.SocketException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 
-public class NonBlockingStatsDClientTest {
+@RunWith(Parameterized.class)
+public class StatsDClientTest {
 
     private static final int STATSD_SERVER_PORT = 17254;
-    private static final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT);
+    private final StatsDClient client;
     private static DummyStatsDServer server;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[]{ NonBlockingStatsDClient.class },
+                new Object[]{ BlockingStatsDClient.class} );
+    }
+
+    public StatsDClientTest(Class<? extends StatsDClient> client) throws Exception {
+        this.client = client
+                .getConstructor(String.class, String.class, Integer.TYPE)
+                .newInstance("my.prefix", "localhost", STATSD_SERVER_PORT);
+    }
 
     @BeforeClass
     public static void start() throws SocketException {
@@ -25,12 +43,12 @@ public class NonBlockingStatsDClientTest {
 
     @AfterClass
     public static void stop() throws Exception {
-        client.stop();
         server.close();
     }
 
     @After
     public void clear() {
+        client.stop();
         server.clear();
     }
 


### PR DESCRIPTION
Adding client without queue and separate executor which is useful in cases where reporting stats already is performed within dedicated executor.
Note that the blocking client is potentially unsafe when used in regular code as it propagates exceptions instead of reporting them asynchronously.

See https://github.com/DataDog/java-dogstatsd-client/issues/20