### PR TITLE
Add close method to StatsDClient and extend Closeable

### DIFF
--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -9,6 +9,7 @@ package com.timgroup.statsd;
  */
 public final class NoOpStatsDClient implements StatsDClient {
 	@Override public void stop() { }
+    @Override public void close() { }
     @Override public void count(String aspect, long delta, String... tags) { }
     @Override public void count(String aspect, long delta, double sampleRate, String... tags) { }
     @Override public void incrementCounter(String aspect, String... tags) { }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -345,6 +345,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         }
     }
 
+    @Override
+    public void close() {
+        stop();
+    }
+
     /**
      * Generate a suffix conveying the given tag list to the client
      */

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -1,5 +1,7 @@
 package com.timgroup.statsd;
 
+import java.io.Closeable;
+
 /**
  * Describes a client connection to a StatsD server, which may be used to post metrics
  * in the form of counters, timers, and gauges.
@@ -15,13 +17,19 @@ package com.timgroup.statsd;
  * @author Tom Denley
  *
  */
-public interface StatsDClient {
+public interface StatsDClient extends Closeable {
 
     /**
      * Cleanly shut down this StatsD client. This method may throw an exception if
      * the socket cannot be closed.
      */
     void stop();
+
+    /**
+     * @see #stop()
+     */
+    @Override
+    void close();
 
     /**
      * Adjusts the specified counter by a given delta.


### PR DESCRIPTION
This makes the client more straightforward to use in a Spring project as
a Bean. Spring detects methods named "close" or "shutdown" and calls
them when shutting down, see [documentation](https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/context/annotation/Bean.java#L243-L245).