### PR TITLE
Support for floating-point delta in counters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
-  - openjdk6
 
 install: mvn install -DskipTests -Dgpg.skip

--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -12,6 +12,8 @@ public final class NoOpStatsDClient implements StatsDClient {
     @Override public void close() { }
     @Override public void count(String aspect, long delta, String... tags) { }
     @Override public void count(String aspect, long delta, double sampleRate, String... tags) { }
+    @Override public void count(String aspect, double delta, String... tags) { }
+    @Override public void count(String aspect, double delta, double sampleRate, String... tags) { }
     @Override public void incrementCounter(String aspect, String... tags) { }
     @Override public void incrementCounter(String aspect, double sampleRate, String... tags) { }
     @Override public void increment(String aspect, String... tags) { }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -413,6 +413,34 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
+     * Adjusts the specified counter by a given delta.
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the counter to adjust
+     * @param delta
+     *     the amount to adjust the counter by
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    @Override
+    public void count(final String aspect, final double delta, final String... tags) {
+        send(String.format("%s%s:%f|c%s", prefix, aspect, delta, tagString(tags)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void count(final String aspect, final double delta, final double sampleRate, final String...tags) {
+        if(isInvalidSample(sampleRate)) {
+            return;
+        }
+        send(String.format("%s%s:%f|c|@%f%s", prefix, aspect, delta, sampleRate, tagString(tags)));
+    }
+
+    /**
      * Increments the specified counter by one.
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -426,7 +426,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void count(final String aspect, final double delta, final String... tags) {
-        send(String.format("%s%s:%f|c%s", prefix, aspect, delta, tagString(tags)));
+        send(String.format("%s%s:%s|c%s", prefix, aspect, NUMBER_FORMATTERS.get().format(delta), tagString(tags)));
     }
 
     /**
@@ -437,7 +437,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         if(isInvalidSample(sampleRate)) {
             return;
         }
-        send(String.format("%s%s:%f|c|@%f%s", prefix, aspect, delta, sampleRate, tagString(tags)));
+        send(String.format("%s%s:%s|c|@%f%s", prefix, aspect, NUMBER_FORMATTERS.get().format(delta), sampleRate, tagString(tags)));
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -64,7 +64,41 @@ public interface StatsDClient extends Closeable {
      *     array of tags to be added to the data
      */
     void count(String aspect, long delta, double sampleRate, String... tags);
-    
+
+    /**
+     * Adjusts the specified counter by a given delta.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the counter to adjust
+     * @param delta
+     *     the amount to adjust the counter by
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void count(String aspect, double delta, String... tags);
+
+    /**
+     * Adjusts the specified counter by a given delta.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the counter to adjust
+     * @param delta
+     *     the amount to adjust the counter by
+     * @param sampleRate
+     * 		percentage of time metric to be sent
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void count(String aspect, double delta, double sampleRate, String... tags);
+
     /**
      * Increments the specified counter by one.
      *


### PR DESCRIPTION
This is already supported in other libraries like [dogstatsd-ruby](http://www.rubydoc.info/github/DataDog/dogstatsd-ruby/Datadog/Statsd#increment-instance_method) library and it'd be nice if we can use it in java-dogstatsd-client too.