### PR TITLE
Add UDS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ public class Foo {
   }
 }
 ```
+
+Unix Domain Socket support
+---------------------------
+java.io.IOException: No such file or directory
+java.io.IOException: No buffer space available
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ public class Foo {
 
 Unix Domain Socket support
 ---------------------------
-java.io.IOException: No such file or directory
-java.io.IOException: No buffer space available
+
+As an alternative to UDP, Agent6 can receive metrics via a UNIX Socket (on Linux only). This library supports
+transmission via this protocol. To use it, simply pass the socket path as a hostname, and 0 as port.
+
+By default, all exceptions are ignored, mimicking UDP behaviour. When using Unix Sockets, transmission errors will
+trigger exceptions you can choose to handle by passing a `StatsDClientErrorHandler`:
+
+- Connection error because of an invalid/missing socket will trigger a `java.io.IOException: No such file or directory`
+- If dogstatsd's reception buffer were to fill up, the send will timeout after 100ms and throw either a
+`java.io.IOException: No buffer space available` or a `java.io.IOException: Resource temporarily unavailable`
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
       <scope>test</scope>
       <version>4.12</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-unixsocket</artifactId>
+      <version>0.18</version>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -2,6 +2,7 @@ package com.timgroup.statsd;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.SocketAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
@@ -19,7 +20,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixDatagramChannel;
 
 
 /**
@@ -288,7 +290,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     public NonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
-                                   final Callable<InetSocketAddress> addressLookup) throws StatsDClientException {
+                                   final Callable<SocketAddress> addressLookup) throws StatsDClientException {
         if((prefix != null) && (!prefix.isEmpty())) {
             this.prefix = String.format("%s.", prefix);
         } else {
@@ -313,7 +315,12 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         }
 
         try {
-            clientChannel = DatagramChannel.open();
+            final SocketAddress address = addressLookup.call();
+            if (address instanceof UnixSocketAddress) {
+                clientChannel = UnixDatagramChannel.open();
+            } else{
+                clientChannel = DatagramChannel.open();
+            }
         } catch (final Exception e) {
             throw new StatsDClientException("Failed to start StatsD client", e);
         }
@@ -883,10 +890,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     private class QueueConsumer implements Runnable {
         private final ByteBuffer sendBuffer = ByteBuffer.allocate(PACKET_SIZE_BYTES);
+        private final Callable<SocketAddress> addressLookup;
 
-        private final Callable<InetSocketAddress> addressLookup;
 
-        QueueConsumer(final Callable<InetSocketAddress> addressLookup) {
+
+        QueueConsumer(final Callable<SocketAddress> addressLookup) {
             this.addressLookup = addressLookup;
         }
 
@@ -895,7 +903,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
                 try {
                     final String message = queue.poll(1, TimeUnit.SECONDS);
                     if(null != message) {
-                        final InetSocketAddress address = addressLookup.call();
+                        final SocketAddress address = addressLookup.call();
                         final byte[] data = message.getBytes(MESSAGE_CHARSET);
                         if(sendBuffer.remaining() < (data.length + 1)) {
                             blockingSend(address);
@@ -914,7 +922,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
             }
         }
 
-        private void blockingSend(final InetSocketAddress address) throws IOException {
+        private void blockingSend(final SocketAddress address) throws IOException {
             final int sizeOfBuffer = sendBuffer.position();
             sendBuffer.flip();
 
@@ -926,10 +934,9 @@ public final class NonBlockingStatsDClient implements StatsDClient {
                 handler.handle(
                         new IOException(
                             String.format(
-                                "Could not send entirely stat %s to host %s:%d. Only sent %d bytes out of %d bytes",
+                                "Could not send entirely stat %s to %s. Only sent %d bytes out of %d bytes",
                                 sendBuffer.toString(),
-                                address.getHostName(),
-                                address.getPort(),
+                                address.toString(),
                                 sentBytes,
                                 sizeOfBuffer)));
             }
@@ -943,10 +950,14 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      * @param port     the port of the targeted StatsD server
      * @return a function to perform the lookup
      */
-    public static Callable<InetSocketAddress> volatileAddressResolution(final String hostname, final int port) {
-        return new Callable<InetSocketAddress>() {
-            @Override public InetSocketAddress call() throws UnknownHostException {
-                return new InetSocketAddress(InetAddress.getByName(hostname), port);
+    public static Callable<SocketAddress> volatileAddressResolution(final String hostname, final int port) {
+        return new Callable<SocketAddress>() {
+            @Override public SocketAddress call() throws UnknownHostException {
+                if (port == 0) { // Hostname is a file path to the socket
+                    return new UnixSocketAddress(hostname);
+                } else {
+                    return new InetSocketAddress(InetAddress.getByName(hostname), port);
+                }
             }
         };
     }
@@ -959,16 +970,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
    * @return a function that cached the result of the lookup
    * @throws Exception if the lookup fails, i.e. {@link UnknownHostException}
    */
-    public static Callable<InetSocketAddress> staticAddressResolution(final String hostname, final int port) throws Exception {
-        final InetSocketAddress address = volatileAddressResolution(hostname, port).call();
-        return new Callable<InetSocketAddress>() {
-            @Override public InetSocketAddress call() {
+    public static Callable<SocketAddress> staticAddressResolution(final String hostname, final int port) throws Exception {
+        final SocketAddress address = volatileAddressResolution(hostname, port).call();
+        return new Callable<SocketAddress>() {
+            @Override public SocketAddress call() {
                 return address;
             }
         };
     }
 
-    private static Callable<InetSocketAddress> staticStatsDAddressResolution(final String hostname, final int port) throws StatsDClientException {
+    private static Callable<SocketAddress> staticStatsDAddressResolution(final String hostname, final int port) throws StatsDClientException {
         try {
             return staticAddressResolution(hostname, port);
         } catch (final Exception e) {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixDatagramChannel;
+import jnr.unixsocket.UnixSocketOptions;
 
 
 /**
@@ -318,6 +319,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
             final SocketAddress address = addressLookup.call();
             if (address instanceof UnixSocketAddress) {
                 clientChannel = UnixDatagramChannel.open();
+                clientChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, Integer.valueOf(100));
             } else{
                 clientChannel = DatagramChannel.open();
             }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -319,6 +319,8 @@ public final class NonBlockingStatsDClient implements StatsDClient {
             final SocketAddress address = addressLookup.call();
             if (address instanceof UnixSocketAddress) {
                 clientChannel = UnixDatagramChannel.open();
+                // Set send timeout to 100ms, to handle the case where the transmission buffer is full
+                // If no timeout is set, the send becomes blocking
                 clientChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, Integer.valueOf(100));
             } else{
                 clientChannel = DatagramChannel.open();

--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -40,7 +40,7 @@ final class DummyStatsDServer {
                             Thread.sleep(10);
                         } catch (InterruptedException e) {
                         }
-                    } else{
+                    } else {
                         try {
                             packet.clear();
                             server.receive(packet);

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -40,7 +40,7 @@ public final class NonBlockingStatsDClientPerfTest {
         for(int i = 0; i < testSize; ++i) {
             executor.submit(new Runnable() {
                 public void run() {
-                    client.count("mycount", RAND.nextInt());
+                    client.count("mycount", 1);
                 }
             });
 
@@ -49,7 +49,7 @@ public final class NonBlockingStatsDClientPerfTest {
         executor.shutdown();
         executor.awaitTermination(20, TimeUnit.SECONDS);
 
-        for(int i = 0; i < 20000 && server.messagesReceived().size() < testSize; i += 50) {
+        while(server.messagesReceived().size() < testSize) {
             try {
                 Thread.sleep(50);
             } catch (InterruptedException ex) {}

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -1,6 +1,7 @@
 package com.timgroup.statsd;
 
 
+import java.io.IOException;
 import java.net.SocketException;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
@@ -22,7 +23,7 @@ public final class NonBlockingStatsDClientPerfTest {
     private static DummyStatsDServer server;
 
     @BeforeClass
-    public static void start() throws SocketException {
+    public static void start() throws IOException {
         server = new DummyStatsDServer(STATSD_SERVER_PORT);
     }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -19,7 +19,7 @@ public final class NonBlockingStatsDClientPerfTest {
     private static final int STATSD_SERVER_PORT = 17255;
     private static final Random RAND = new Random();
     private static final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT);
-    private final ExecutorService executor = Executors.newFixedThreadPool(20);
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
     private static DummyStatsDServer server;
 
     @BeforeClass

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.SocketException;
 import java.util.Locale;
 
@@ -19,7 +20,7 @@ public class NonBlockingStatsDClientTest {
     private static DummyStatsDServer server;
 
     @BeforeClass
-    public static void start() throws SocketException {
+    public static void start() throws IOException {
         server = new DummyStatsDServer(STATSD_SERVER_PORT);
     }
 

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -105,6 +105,7 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         server.freeze();
         while(lastException.getMessage() == null) {
             client.gauge("mycount", 20);
+            Thread.sleep(50);
         }
         assertThat(lastException.getMessage(), containsString("No buffer space available"));
 

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -1,7 +1,9 @@
 package com.timgroup.statsd;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import java.io.IOException;
 import java.io.File;
@@ -22,6 +24,11 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
 
     public void handle(Exception exception) {
         lastException = exception;
+    }
+
+    @BeforeClass
+    public static void linuxOnly() throws IOException {
+        Assume.assumeThat(System.getProperty("os.name"), containsString("Linux"));
     }
 
     @Before

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -1,0 +1,121 @@
+package com.timgroup.statsd;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.IOException;
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+
+public class UnixSocketTest implements StatsDClientErrorHandler {
+    private static File tmpFolder;
+    private static NonBlockingStatsDClient client;
+    private static DummyStatsDServer server;
+    private Exception lastException = new Exception();
+    private static File socketFile;
+
+    public void handle(Exception exception) {
+        lastException = exception;
+    }
+
+    @Before
+    public void start() throws IOException {
+        tmpFolder = Files.createTempDirectory(System.getProperty("java-dsd-test")).toFile();
+        tmpFolder.deleteOnExit();
+        socketFile = new File(tmpFolder, "socket.sock");
+        socketFile.deleteOnExit();
+
+        server = new DummyStatsDServer(socketFile.toString());
+        client = new NonBlockingStatsDClient("my.prefix", socketFile.toString(), 0, null, this);
+    }
+
+    @After
+    public void stop() throws Exception {
+        client.stop();
+        server.close();
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_to_statsd() throws Exception {
+        for(long i = 0; i < 5 ; i++) {
+            client.gauge("mycount", i);
+            server.waitForMessage();
+            String expected = String.format("my.prefix.mycount:%d|g", i);
+            assertThat(server.messagesReceived(), contains(expected));
+            server.clear();
+        }
+        assertThat(lastException.getMessage(), nullValue());
+    }
+
+    @Test(timeout = 10000L)
+    public void resist_dsd_restart() throws Exception {
+        client.gauge("mycount", 10);
+        server.waitForMessage();
+        assertThat(server.messagesReceived(), contains("my.prefix.mycount:10|g"));
+        server.clear();
+        assertThat(lastException.getMessage(), nullValue());
+
+        // Close the server, client should throw an IOException
+        server.close();
+        client.gauge("mycount", 20);
+        while(lastException.getMessage() == null) {
+            // Wait until we flush and get the exception
+            Thread.sleep(10);
+        }
+        assertThat(lastException.getMessage(), containsString("Connection refused"));
+
+        // Delete the socket file, client should throw an IOException
+        lastException = new Exception();
+        socketFile.delete();
+        client.gauge("mycount", 20);
+        while(lastException.getMessage() == null) {
+            // Wait until we flush and get the exception
+            Thread.sleep(10);
+        }
+        assertThat(lastException.getMessage(), containsString("No such file or directory"));
+
+        // Re-open the server, next send should work OK
+        lastException = new Exception();
+        DummyStatsDServer server2 = new DummyStatsDServer(socketFile.toString());
+
+        client.gauge("mycount", 30);
+        server2.waitForMessage();
+
+        assertThat(server2.messagesReceived(), hasItem("my.prefix.mycount:30|g"));
+        server2.clear();
+        assertThat(lastException.getMessage(), nullValue());
+        server2.close();
+    }
+
+    @Test(timeout = 10000L)
+    public void resist_dsd_timeout() throws Exception {
+        client.gauge("mycount", 10);
+        server.waitForMessage();
+        assertThat(server.messagesReceived(), contains("my.prefix.mycount:10|g"));
+        server.clear();
+        assertThat(lastException.getMessage(), nullValue());
+
+        // Freeze the server to simulate dsd being overwhelmed
+        server.freeze();
+        while(lastException.getMessage() == null) {
+            client.gauge("mycount", 20);
+        }
+        assertThat(lastException.getMessage(), containsString("No buffer space available"));
+
+        // Make sure we recover after we resume listening
+        server.unfreeze();
+        while (!server.messagesReceived().contains("my.prefix.mycount:30|g")) {
+            server.clear();
+            client.gauge("mycount", 30);
+            server.waitForMessage();
+        }
+        assertThat(server.messagesReceived(), hasItem("my.prefix.mycount:30|g"));
+        server.clear();
+    }
+}

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -32,7 +32,7 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         socketFile.deleteOnExit();
 
         server = new DummyStatsDServer(socketFile.toString());
-        client = new NonBlockingStatsDClient("my.prefix", socketFile.toString(), 0, null, this);
+        client = new NonBlockingStatsDClient("my.prefix", socketFile.toString(), 0, 1, null, this);
     }
 
     @After
@@ -103,9 +103,9 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         server.freeze();
         while(lastException.getMessage() == null) {
             client.gauge("mycount", 20);
-            Thread.sleep(1);  // We need to fill the buffer, setting a shorter sleep
+            Thread.sleep(10);  // We need to fill the buffer, setting a shorter sleep
         }
-        assertThat(lastException.getMessage(), containsString("No buffer space available"));
+        assertThat(lastException.getMessage(), containsString("Resource temporarily unavailable"));
 
         // Make sure we recover after we resume listening
         server.clear();


### PR DESCRIPTION
This PR adds support for submission of custom metrics through a Unix Socket on Linux.
See https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support for context and benefits.

Implementation details:

- no change in the public API, UDS mode is triggered by setting `0` as port, the socket path as `hostname`
- the send timeout is set at `100ms`. It only triggers if dogstatsd is overloaded/frozen and the socket buffer is full. The equivalent in UDP is a full reception buffer, triggering a silent packet drop
- the default behaviour of the library is to ignore all exceptions, but a custom handler can be passed. Documented the expected exceptions and their meaning

# Testing

- Reduced the parallelism of NonBlockingStatsDClientPerfTest (from 20 to 10) to reduce flakes on Travis
- Added the `UnixSocketTest` test class to test good transmission + error handling and recovery

# Windows

The feature is Linux only, and requires an external `jnr.unixsocket` JNI library. This library provides NOOP stubs for unsupported OSes, so the library still compiles and operates in UDP mode with no dark magic.

Tests pass on windows, all of the `UnixSocketTest` class is ignored of course. As with Linux, the `NonBlockingStatsDClientPerfTest` test is still a bit flaky.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.timgroup.statsd.EventTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.047 sec
Running com.timgroup.statsd.NonBlockingStatsDClientPerfTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.172 sec
Running com.timgroup.statsd.NonBlockingStatsDClientTest
Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.703 sec
Running com.timgroup.statsd.UnixSocketTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 sec

Results :

Tests run: 51, Failures: 0, Errors: 0, Skipped: 1
```