### PR TITLE
Enforce java version for build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,26 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.7.0-0,1.9.0-0)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.4</version>
         <executions>


### PR DESCRIPTION
Ensure that the build environments that test and produce the artifact for this library are constrained to specific versions of Java. (1.7-1.8 for now)

Tests will fail if the java version isn't 1.7 or 1.8. 