### PR TITLE
unix: make timeout and buffer size configurable

### DIFF
--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.SocketException;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -39,7 +39,7 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         socketFile.deleteOnExit();
 
         server = new DummyStatsDServer(socketFile.toString());
-        client = new NonBlockingStatsDClient("my.prefix", socketFile.toString(), 0, 1, null, this);
+        client = new NonBlockingStatsDClient("my.prefix", socketFile.toString(), 0, 1,  100, 1024 * 1024, null, this);
     }
 
     @After


### PR DESCRIPTION
This helps avoiding errors when sending a lot of metrics with a low frequency.