### PR TITLE
Ignore post test exception

### DIFF
--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -25,8 +25,12 @@ public class NonBlockingStatsDClientTest {
 
     @AfterClass
     public static void stop() throws Exception {
-        client.stop();
-        server.close();
+        try {
+            client.stop();
+            server.close();
+        } catch (java.io.IOException e) {
+            return;
+        }
     }
 
     @After


### PR DESCRIPTION
Closing a DatagramChannel can have issues on Java8. Closing our test DummyStatsd server can encounter this error on Mac OSX - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7133499 or - https://bugs.openjdk.java.net/browse/JDK-8050499

This PR catches that exception. Its important to note this doesn't impact what the actual tests are testing for, this only impacts the closing of the Dummy server after all tests have been run. 