### PR TITLE
Wait for the server to process the expected message in shutdown test

### DIFF
--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -623,6 +623,7 @@ public class NonBlockingStatsDClientTest {
             client.count("mycounter", 5);
             assertEquals(0, server.messagesReceived().size());
             client.stop();
+            server.waitForMessage();
             assertEquals(1, server.messagesReceived().size());
         } finally {
             client.stop();


### PR DESCRIPTION
`client.stop()` should make sure that the client sends the lingering message appropriately, but we could check for the messages the serve has received before it's actually had a chance to listen and fully process the expected message.