### PR TITLE
[travis-ci] trusty distribution no longer default - explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 dist: trusty
 language: java
 jdk:
-  - oraclejdk8
   - openjdk7
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
 
 install: mvn install -DskipTests -Dgpg.skip

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.7.0-0,1.9.0-0)</version>
+                  <version>[1.7.0-0,1.9.0-0),[9.0,11.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.7.0-0,1.9.0-0),[9.0,11.0)</version>
+                  <version>[1.7.0-0,1.9.0-0),[9.0.0,11.0.5]</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -137,7 +137,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.1.0</version>
+        <configuration>
+          <source>1.7</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Tests were failing as `trusty` is no longer the default image on travis and the ancient java distros were not supported. 

As a side-bonus adding some newer java versions to also make sure nothing breaks in current versions (forward-compatibility not expected to be an issue 🤞).