### PR TITLE
Bump jnr-unixsocket to 0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.18</version>
+      <version>0.27</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What does this PR do?

Upgrades the jnr-unixsocket dependency to 0.27, so that it uses the new version of jffi (1.2.23) which passes the MacOS notarization test.

