### PR TITLE
[java] add back support for old constructors

### DIFF
--- a/src/main/java/com/timgroup/statsd/BufferPool.java
+++ b/src/main/java/com/timgroup/statsd/BufferPool.java
@@ -8,11 +8,16 @@ import java.util.concurrent.BlockingQueue;
 public class BufferPool {
     private final BlockingQueue<ByteBuffer> pool;
     private final int size;
+    private final int bufferSize;
+    private final boolean direct;
 
 
     BufferPool(final int poolSize, int bufferSize, final boolean direct) throws InterruptedException {
 
         size = poolSize;
+        this.bufferSize = bufferSize;
+        this.direct = direct;
+
         pool = new ArrayBlockingQueue<ByteBuffer>(poolSize);
         for (int i = 0; i < size ; i++) {
             if (direct) {
@@ -23,12 +28,30 @@ public class BufferPool {
         }
     }
 
+    BufferPool(final BufferPool pool) throws InterruptedException {
+        this.size = pool.size;
+        this.bufferSize = pool.bufferSize;
+        this.direct = pool.direct;
+        this.pool = new ArrayBlockingQueue<ByteBuffer>(pool.size);
+        for (int i = 0; i < size ; i++) {
+            if (direct) {
+                this.pool.put(ByteBuffer.allocateDirect(bufferSize));
+            } else {
+                this.pool.put(ByteBuffer.allocate(bufferSize));
+            }
+        }
+    }
+
     ByteBuffer borrow() throws InterruptedException {
         return pool.take();
     }
 
     void put(ByteBuffer buffer) throws InterruptedException {
         pool.put(buffer);
+    }
+
+    int getSize() {
+        return size;
     }
 
     int available() {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -301,7 +301,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
      * specified host and port.
-     *
      * This is a shallow copy constructor meant to be used internally only.
      *
      * @param client
@@ -309,12 +308,12 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     private NonBlockingStatsDClient(NonBlockingStatsDClient client) {
 
-            this.prefix = client.prefix;
-            this.handler = client.handler;
-            this.constantTagsRendered = client.constantTagsRendered;
-            this.clientChannel = client.clientChannel;
-            this.statsDProcessor = client.statsDProcessor;
-            this.statsDSender = client.statsDSender;
+        this.prefix = client.prefix;
+        this.handler = client.handler;
+        this.constantTagsRendered = client.constantTagsRendered;
+        this.clientChannel = client.clientChannel;
+        this.statsDProcessor = client.statsDProcessor;
+        this.statsDSender = client.statsDSender;
     }
 
 
@@ -398,7 +397,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final int queueSize) throws StatsDClientException {
 
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
@@ -433,7 +433,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final String... constantTags) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final String... constantTags) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -469,7 +470,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final String[] constantTags, final int maxPacketSizeBytes) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final String[] constantTags, final int maxPacketSizeBytes) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -506,7 +508,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize, final String... constantTags) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final int queueSize, final String... constantTags) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -544,8 +547,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
-                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix,final String hostname, final int port,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler)
+        throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -586,7 +590,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Deprecated
     public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
-                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+            final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -633,7 +637,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Deprecated
     public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
-                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler, String entityID) throws StatsDClientException {
+            final String[] constantTags, final StatsDClientErrorHandler errorHandler, String entityID)
+        throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -678,8 +683,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
-                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler, final int maxPacketSizeBytes) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final int queueSize, final String[] constantTags, final StatsDClientErrorHandler errorHandler,
+            final int maxPacketSizeBytes) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -725,8 +731,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize, int timeout, int bufferSize,
-                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+            final int queueSize, int timeout, int bufferSize, final String[] constantTags,
+            final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .hostname(hostname)
@@ -764,8 +771,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
-                                   final Callable<SocketAddress> addressLookup) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags,
+            final StatsDClientErrorHandler errorHandler, final Callable<SocketAddress> addressLookup)
+        throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .queueSize(queueSize)
@@ -804,8 +812,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
-                                   final Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags,
+            final StatsDClientErrorHandler errorHandler, final Callable<SocketAddress> addressLookup,
+            final int timeout, final int bufferSize) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .queueSize(queueSize)
@@ -848,8 +857,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     @Deprecated
-    public NonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
-                                   final Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize, final int maxPacketSizeBytes) throws StatsDClientException {
+    public NonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags,
+            final StatsDClientErrorHandler errorHandler, final Callable<SocketAddress> addressLookup,
+            final int timeout, final int bufferSize, final int maxPacketSizeBytes) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
             .queueSize(queueSize)

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -321,6 +321,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
             throw new StatsDClientException("Failed to instantiate StatsD client copy", e);
         }
 
+        telemetry = new Telemetry(client.telemetry.getTags(), statsDProcessor);
+
         executor.submit(statsDProcessor);
         executor.submit(statsDSender);
     }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -298,6 +298,570 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
     }
 
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port.
+     *
+     * This is a shallow copy constructor meant to be used internally only.
+     *
+     * @param client
+     *    source object to copy
+     */
+    private NonBlockingStatsDClient(NonBlockingStatsDClient client) {
+
+            this.prefix = client.prefix;
+            this.handler = client.handler;
+            this.constantTagsRendered = client.constantTagsRendered;
+            this.clientChannel = client.clientChannel;
+            this.statsDProcessor = client.statsDProcessor;
+            this.statsDSender = client.statsDSender;
+    }
+
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance. It
+     * uses Environment variables ("DD_AGENT_HOST" and "DD_DOGSTATSD_PORT")
+     * in order to configure the communication with a StatsD instance.
+     * All messages send via this client will have their keys prefixed with
+     * the specified string. The new client will attempt to open a connection
+     * to the StatsD server immediately upon instantiation, and may throw an
+     * exception if that a connection cannot be established. Once a client has
+     * been instantiated in this way, all exceptions thrown during subsequent
+     * usage are consumed, guaranteeing that failures in metrics will not
+     * affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are consumed, guaranteeing
+     * that failures in metrics will not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are consumed, guaranteeing
+     * that failures in metrics will not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize) throws StatsDClientException {
+
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are consumed, guaranteeing
+     * that failures in metrics will not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final String... constantTags) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .constantTags(constantTags)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are consumed, guaranteeing
+     * that failures in metrics will not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param maxPacketSizeBytes
+     *     the maximum number of bytes for a message that can be sent
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final String[] constantTags, final int maxPacketSizeBytes) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .constantTags(constantTags)
+            .maxPacketSizeBytes(maxPacketSizeBytes)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are consumed, guaranteeing
+     * that failures in metrics will not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize, final String... constantTags) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .build());
+    }
+
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @param entityID
+     *     the entity id value used with an internal tag for tracking client entity.
+     *     If "entityID=null" the client default the value with the environment variable "DD_ENTITY_ID".
+     *     If the environment variable is not defined, the internal tag is not added.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler, String entityID) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .entityID(entityID)
+            .build());
+    }
+
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @param maxPacketSizeBytes
+     *     the maximum number of bytes for a message that can be sent
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler, final int maxPacketSizeBytes) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .maxPacketSizeBytes(maxPacketSizeBytes)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param hostname
+     *     the host name of the targeted StatsD server. If 'null' the environment variable
+     *     "DD_AGENT_HOST" is used to get the host name.
+     * @param port
+     *     the port of the targeted StatsD server. If the parameter 'hostname' is 'null' and
+     *     this parameter is equal to '0', the environment variable
+     *     "DD_DOGSTATSD_PORT" is used to get the port, else the default value '8125' is used.
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @param timeout
+     *     the timeout in milliseconds for blocking operations. Applies to unix sockets only.
+     * @param bufferSize
+     *     the socket buffer size in bytes. Applies to unix sockets only.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final String hostname, final int port, final int queueSize, int timeout, int bufferSize,
+                                   final String[] constantTags, final StatsDClientErrorHandler errorHandler) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .hostname(hostname)
+            .port(port)
+            .queueSize(queueSize)
+            .timeout(timeout)
+            .socketBufferSize(bufferSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
+                                   final Callable<SocketAddress> addressLookup) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .addressLookup(addressLookup)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @param timeout
+     *     the timeout in milliseconds for blocking operations. Applies to unix sockets only.
+     * @param bufferSize
+     *     the socket buffer size in bytes. Applies to unix sockets only.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
+                                   final Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .addressLookup(addressLookup)
+            .timeout(timeout)
+            .socketBufferSize(bufferSize)
+            .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     * @param timeout
+     *     the timeout in milliseconds for blocking operations. Applies to unix sockets only.
+     * @param bufferSize
+     *     the socket buffer size in bytes. Applies to unix sockets only.
+     * @param maxPacketSizeBytes
+     *     the maximum number of bytes for a message that can be sent
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    @Deprecated
+    public NonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
+                                   final Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize, final int maxPacketSizeBytes) throws StatsDClientException {
+        this(new NonBlockingStatsDClientBuilder()
+            .prefix(prefix)
+            .queueSize(queueSize)
+            .constantTags(constantTags)
+            .errorHandler(errorHandler)
+            .addressLookup(addressLookup)
+            .timeout(timeout)
+            .socketBufferSize(bufferSize)
+            .maxPacketSizeBytes(maxPacketSizeBytes)
+            .build());
+    }
+
     protected StatsDProcessor createProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int bufferPoolSize, final int workers, boolean blocking) throws Exception {
         if (blocking) {

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -100,7 +100,7 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
             throws Exception {
 
         super(processor);
-        this.messages = new ArrayBlockingQueue<String>(processor.getQcapacity());
+        this.messages = new ArrayBlockingQueue<>(processor.getQcapacity());
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -96,6 +96,13 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
         return new ProcessingTask();
     }
 
+    StatsDBlockingProcessor(final StatsDBlockingProcessor processor)
+            throws Exception {
+
+        super(processor);
+        this.messages = new ArrayBlockingQueue<String>(processor.getQcapacity());
+    }
+
     @Override
     protected boolean send(final Message message) {
         try {

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -97,7 +97,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
         super(queueSize, handler, maxPacketSizeBytes, poolSize, workers);
         this.qsize = new AtomicInteger(0);
-        this.qcapacity = queueSize;
         this.messages = new ConcurrentLinkedQueue<>();
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
     private final Queue<Message> messages;
-    private final int qcapacity;
     private final AtomicInteger qsize;  // qSize will not reflect actual size, but a close estimate.
 
     private class ProcessingTask extends StatsDProcessor.ProcessingTask {
@@ -105,6 +104,12 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     @Override
     protected ProcessingTask createProcessingTask() {
         return new ProcessingTask();
+    }
+
+    StatsDNonBlockingProcessor(final StatsDNonBlockingProcessor processor) throws Exception {
+        super(processor);
+        this.qsize = new AtomicInteger(0);
+        this.messages = new ConcurrentLinkedQueue<>();
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -58,11 +58,13 @@ public class StatsDSender implements Runnable {
     }
 
     StatsDSender(final StatsDSender sender) throws Exception {
-        this(sender.addressLookup, sender.clientChannel, sender.handler, sender.pool, sender.buffers, sender.workers);
+        this(sender.addressLookup, sender.clientChannel, sender.handler,
+                sender.pool, sender.buffers, sender.workers, sender.telemetry);
     }
 
     StatsDSender(final StatsDSender sender, BufferPool pool, BlockingQueue<ByteBuffer> buffers) throws Exception {
-        this(sender.addressLookup, sender.clientChannel, sender.handler, pool, buffers, sender.workers);
+        this(sender.addressLookup, sender.clientChannel, sender.handler,
+                pool, buffers, sender.workers, sender.telemetry);
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -57,6 +57,14 @@ public class StatsDSender implements Runnable {
         this(addressLookup, clientChannel, handler, pool, buffers, DEFAULT_WORKERS, telemetry);
     }
 
+    StatsDSender(final StatsDSender sender) throws Exception {
+        this(sender.addressLookup, sender.clientChannel, sender.handler, sender.pool, sender.buffers, sender.workers);
+    }
+
+    StatsDSender(final StatsDSender sender, BufferPool pool, BlockingQueue<ByteBuffer> buffers) throws Exception {
+        this(sender.addressLookup, sender.clientChannel, sender.handler, pool, buffers, sender.workers);
+    }
+
     @Override
     public void run() {
 

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -71,6 +71,8 @@ public class Telemetry {
     }
 
     Telemetry(final String tags, final StatsDProcessor processor) {
+        this.tags = tags;
+
         // precompute metrics lines with tags
         this.tags = tags;
         this.processor = processor;
@@ -160,5 +162,13 @@ public class Telemetry {
         this.packetsSent.set(0);
         this.packetsDropped.set(0);
         this.packetsDroppedQueue.set(0);
+    }
+
+    /**
+     * Gets the telemetry tags string.
+     * @return this Telemetry instance applied tags.
+     */
+    public String getTags() {
+        return this.tags;
     }
 }

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -71,8 +71,6 @@ public class Telemetry {
     }
 
     Telemetry(final String tags, final StatsDProcessor processor) {
-        this.tags = tags;
-
         // precompute metrics lines with tags
         this.tags = tags;
         this.processor = processor;

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -432,6 +432,15 @@ public class NonBlockingStatsDClientTest {
         assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|@1.000000|#baz,foo:bar"));
     }
 
+    @Test(timeout = 5000L)
+    public void sends_gauge_mixed_tags_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, "instance:foo", "app:bar");
+        empty_prefix_client.gauge("value", 423, "baz");
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#app:bar,instance:foo,baz"));
+    }
 
     @Test(timeout = 5000L)
     public void sends_gauge_mixed_tags() throws Exception {
@@ -446,6 +455,16 @@ public class NonBlockingStatsDClientTest {
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#app:bar,instance:foo,baz"));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_mixed_tags_with_sample_rate_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, "instance:foo", "app:bar");
+        empty_prefix_client.gauge("value", 423, 1, "baz");
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|@1.000000|#app:bar,instance:foo,baz"));
     }
 
     @Test(timeout = 5000L)
@@ -464,6 +483,16 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_gauge_constant_tags_only_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, "instance:foo", "app:bar");
+        empty_prefix_client.gauge("value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#app:bar,instance:foo"));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_gauge_constant_tags_only() throws Exception {
 
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClientBuilder().prefix("my.prefix")
@@ -476,6 +505,17 @@ public class NonBlockingStatsDClientTest {
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#app:bar,instance:foo"));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_entityID_from_env_deprecated() throws Exception {
+        final String entity_value =  "foo-entity";
+        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE);
+        client.gauge("value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity"));
     }
 
     @Test(timeout = 5000L)
@@ -494,6 +534,18 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_gauge_entityID_from_env_and_constant_tags_deprecated() throws Exception {
+        final String entity_value =  "foo-entity";
+        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
+        final String constantTags = "arbitraryTag:arbitraryValue";
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, constantTags);
+        client.gauge("value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_gauge_entityID_from_env_and_constant_tags() throws Exception {
         final String entity_value =  "foo-entity";
         environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
@@ -507,6 +559,17 @@ public class NonBlockingStatsDClientTest {
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_entityID_from_args_deprecated() throws Exception {
+        final String entity_value =  "foo-entity";
+        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, null, null, entity_value+"-arg");
+        client.gauge("value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg"));
     }
 
     @Test(timeout = 5000L)
@@ -563,6 +626,16 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_gauge_empty_prefix_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("", "localhost", STATSD_SERVER_PORT);
+        empty_prefix_client.gauge("top.level.value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("top.level.value:423|g"));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_gauge_empty_prefix() throws Exception {
 
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClientBuilder().prefix("")
@@ -570,6 +643,16 @@ public class NonBlockingStatsDClientTest {
             .port(STATSD_SERVER_PORT)
             .build();
         empty_prefix_client.gauge("top.level.value", 423);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("top.level.value:423|g"));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_null_prefix_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient null_prefix_client = new NonBlockingStatsDClient(null, "localhost", STATSD_SERVER_PORT);
+        null_prefix_client.gauge("top.level.value", 423);
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("top.level.value:423|g"));
@@ -667,6 +750,26 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_event_empty_prefix_deprecated() throws Exception {
+
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("", "localhost", STATSD_SERVER_PORT);
+        final Event event = Event.builder()
+                .withTitle("title1")
+                .withText("text1")
+                .withDate(1234567000)
+                .withHostname("host1")
+                .withPriority(Event.Priority.LOW)
+                .withAggregationKey("key1")
+                .withAlertType(Event.AlertType.ERROR)
+                .withSourceTypeName("sourcetype1")
+                .build();
+        empty_prefix_client.recordEvent(event, "foo:bar", "baz");
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("_e{6,5}:title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar"));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_event_empty_prefix() throws Exception {
 
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClientBuilder().prefix("")
@@ -743,6 +846,40 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout=5000L)
+    public void sends_too_large_message_deprecated() throws Exception {
+        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
+
+        try (final NonBlockingStatsDClient testClient = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT,  null, errorHandler)) {
+
+            final byte[] messageBytes = new byte[1600];
+            final ServiceCheck tooLongServiceCheck = ServiceCheck.builder()
+                    .withName("toolong")
+                    .withMessage(new String(messageBytes))
+                    .withStatus(ServiceCheck.Status.OK)
+                    .build();
+            testClient.serviceCheck(tooLongServiceCheck);
+
+            final ServiceCheck withinLimitServiceCheck = ServiceCheck.builder()
+                    .withName("fine")
+                    .withStatus(ServiceCheck.Status.OK)
+                    .build();
+            testClient.serviceCheck(withinLimitServiceCheck);
+
+            server.waitForMessage();
+
+            final List<Exception> exceptions = errorHandler.getExceptions();
+            assertEquals(1, exceptions.size());
+            final Exception exception = exceptions.get(0);
+            assertEquals(InvalidMessageException.class, exception.getClass());
+            assertTrue(((InvalidMessageException)exception).getInvalidMessage().startsWith("_sc|toolong|"));
+
+            final List<String> messages = server.messagesReceived();
+            assertEquals(1, messages.size());
+            assertEquals("_sc|fine|0", messages.get(0));
+        }
+    }
+
+    @Test(timeout=5000L)
     public void sends_too_large_message() throws Exception {
         final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
 
@@ -809,11 +946,11 @@ public class NonBlockingStatsDClientTest {
 
         private CountDownLatch lock;
 
-        SlowStatsDNonBlockingStatsDClient(final String prefix,  final int queueSize, String[] constantTags, final StatsDClientErrorHandler errorHandler,
-                                   Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize, final int maxPacketSizeBytes,
-                                   String entityID, final int poolSize, final int processorWorkers, final int senderWorkers,
-                                   boolean blocking)
-                throws StatsDClientException {
+        SlowStatsDNonBlockingStatsDClient(final String prefix,  final int queueSize,
+                String[] constantTags, final StatsDClientErrorHandler errorHandler,
+                Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize,
+                final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
+                final int senderWorkers, boolean blocking) throws StatsDClientException {
             super(prefix, queueSize, constantTags, errorHandler, addressLookup, timeout, bufferSize, maxPacketSizeBytes,
                     entityID, poolSize, processorWorkers, senderWorkers, blocking, false, 0);
             lock = new CountDownLatch(1);


### PR DESCRIPTION
The oid constructor overloading was a bit of a mess, but with a copy constructor and the builder we should have managed to keep the codebase more or less clean, and we can deprecate but keep these constructors around.

We should probably add some tests to ensure these are all 100% backward compatible and safe.