### PR TITLE
[client] reduce the number of allocations

### DIFF
--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -1,0 +1,13 @@
+package com.timgroup.statsd;
+
+interface Message {
+    /**
+     * Write this message to the provided {@link StringBuilder}. Will
+     * only ever be called from the sender thread.
+     *
+     * @param builder
+     *     StringBuilder the text representation will be written to.
+     */
+    void writeTo(StringBuilder builder);
+}
+

--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -3,7 +3,7 @@ package com.timgroup.statsd;
 interface Message {
     /**
      * Write this message to the provided {@link StringBuilder}. Will
-     * only ever be called from the sender thread.
+     * be called from the sender threads.
      *
      * @param builder
      *     StringBuilder the text representation will be written to.

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -247,7 +247,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
             if (costantPreTags.isEmpty()) {
                 constantTagsRendered = null;
             } else {
-                constantTagsRendered = tagString(costantPreTags.toArray(new String[costantPreTags.size()]), null);
+                constantTagsRendered = tagString(
+                        costantPreTags.toArray(new String[costantPreTags.size()]), null, new StringBuilder()).toString();
             }
             costantPreTags = null;
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -23,6 +23,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import com.timgroup.statsd.Message;
+
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
@@ -98,49 +100,32 @@ public class NonBlockingStatsDClient implements StatsDClient {
     };
 
     /**
-     * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
-     * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
-     * http://stackoverflow.com/a/1285297/2648
-     * https://github.com/indeedeng/java-dogstatsd-client/issues/4
+     * The NumberFormat instances are not threadsafe but are only ever called from
+     * the sender thread.
      */
-    private static final ThreadLocal<NumberFormat> NUMBER_FORMATTERS = new ThreadLocal<NumberFormat>() {
-        @Override
-        protected NumberFormat initialValue() {
+    private static final NumberFormat NUMBER_FORMATTER = newFormatter();
+    private static final NumberFormat SAMPLE_RATE_FORMATTER = newFormatter();
 
-            // Always create the formatter for the US locale in order to avoid this bug:
-            // https://github.com/indeedeng/java-dogstatsd-client/issues/3
-            final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
-            numberFormatter.setGroupingUsed(false);
-            numberFormatter.setMaximumFractionDigits(6);
+    static {
+        NUMBER_FORMATTER.setMaximumFractionDigits(6);
+        SAMPLE_RATE_FORMATTER.setMinimumFractionDigits(6);
+    }
 
-            // we need to specify a value for Double.NaN that is recognized by dogStatsD
-            if (numberFormatter instanceof DecimalFormat) { // better safe than a runtime error
-                final DecimalFormat decimalFormat = (DecimalFormat) numberFormatter;
-                final DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
-                symbols.setNaN("NaN");
-                decimalFormat.setDecimalFormatSymbols(symbols);
-            }
+    private static NumberFormat newFormatter() {
+        // Always create the formatter for the US locale in order to avoid this bug:
+        // https://github.com/indeedeng/java-dogstatsd-client/issues/3
+        NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
+        numberFormatter.setGroupingUsed(false);
 
-            return numberFormatter;
+        // we need to specify a value for Double.NaN that is recognized by dogStatsD
+        if (numberFormatter instanceof DecimalFormat) { // better safe than a runtime error
+            final DecimalFormat decimalFormat = (DecimalFormat) numberFormatter;
+            final DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
+            symbols.setNaN("NaN");
+            decimalFormat.setDecimalFormatSymbols(symbols);
         }
-    };
-
-    private static final ThreadLocal<NumberFormat> SAMPLE_RATE_FORMATTERS = new ThreadLocal<NumberFormat>() {
-        @Override
-        protected NumberFormat initialValue() {
-            final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
-            numberFormatter.setGroupingUsed(false);
-            numberFormatter.setMinimumFractionDigits(6);
-
-            if (numberFormatter instanceof DecimalFormat) {
-                final DecimalFormat decimalFormat = (DecimalFormat) numberFormatter;
-                final DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
-                symbols.setNaN("NaN");
-                decimalFormat.setDecimalFormatSymbols(symbols);
-            }
-            return numberFormatter;
-        }
-    };
+        return numberFormatter;
+    }
 
     private final String prefix;
     private final DatagramChannel clientChannel;
@@ -211,7 +196,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                                    final int telemetryFlushInterval)
             throws StatsDClientException {
         if ((prefix != null) && (!prefix.isEmpty())) {
-            this.prefix = new StringBuilder(prefix).append(".").toString();
+            this.prefix = prefix + ".";
         } else {
             this.prefix = "";
         }
@@ -348,35 +333,94 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * Return tag list as a tag string.
      * Generate a suffix conveying the given tag list to the client
      */
-    static String tagString(final String[] tags, final String tagPrefix) {
-        final StringBuilder sb;
-        if (tagPrefix != null) {
-            if ((tags == null) || (tags.length == 0)) {
-                return tagPrefix;
+    static StringBuilder tagString(final String[] tags, final String tagPrefix, final StringBuilder sb) {
+        if(tagPrefix != null) {
+            sb.append(tagPrefix);
+            if((tags == null) || (tags.length == 0)) {
+                return sb;
             }
-            sb = new StringBuilder(tagPrefix);
-            sb.append(",");
+            sb.append(',');
         } else {
-            if ((tags == null) || (tags.length == 0)) {
-                return "";
+            if((tags == null) || (tags.length == 0)) {
+                return sb;
             }
-            sb = new StringBuilder("|#");
+            sb.append("|#");
         }
 
         for (int n = tags.length - 1; n >= 0; n--) {
             sb.append(tags[n]);
-            if (n > 0) {
-                sb.append(",");
+            if(n > 0) {
+                sb.append(',');
             }
         }
-        return sb.toString();
+        return sb;
     }
 
     /**
      * Generate a suffix conveying the given tag list to the client.
      */
-    String tagString(final String[] tags) {
-        return tagString(tags, constantTagsRendered);
+    StringBuilder tagString(final String[] tags, StringBuilder builder) {
+        return tagString(tags, constantTagsRendered, builder);
+    }
+
+    abstract class StatsDMessage implements Message {
+        final String aspect;
+        final String type;
+        final double sampleRate; // NaN for none
+        final String[] tags;
+
+        protected StatsDMessage(String aspect, String type, double sampleRate, String[] tags) {
+            this.aspect = aspect;
+            this.type = type;
+            this.sampleRate = sampleRate;
+            this.tags = tags;
+        }
+
+        @Override
+        public final void writeTo(StringBuilder builder) {
+            builder.append(prefix).append(aspect).append(':');
+            writeValue(builder);
+            builder.append('|').append(type);
+            if (!Double.isNaN(sampleRate)) {
+                builder.append('|').append('@').append(SAMPLE_RATE_FORMATTER.format(sampleRate));
+            }
+            tagString(tags, builder);
+        }
+
+        protected abstract void writeValue(StringBuilder builder);
+    }
+
+    // send double with sample rate
+    private void send(String aspect, final double value, String type, double sampleRate, String[] tags) {
+        if(Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
+
+            statsDProcessor.send(new StatsDMessage(aspect, type, sampleRate, tags) {
+                @Override protected void writeValue(StringBuilder builder) {
+                    builder.append(NUMBER_FORMATTER.format(value));
+                }
+            });
+        }
+    }
+
+    // send double without sample rate
+    private void send(String aspect, final double value, String type, String[] tags) {
+        send(aspect, value, type, Double.NaN, tags);
+    }
+
+    // send long with sample rate
+    private void send(String aspect, final long value, String type, double sampleRate, String[] tags) {
+        if(Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
+            sendMetric(new StatsDMessage(aspect, type, sampleRate, tags) {
+                @Override protected void writeValue(StringBuilder builder) {
+                    builder.append(value);
+                }
+            });
+        }
+    }
+
+    // send long without sample rate
+    private void send(String aspect, final long value, String type, String[] tags) {
+        send(aspect, value, type, Double.NaN, tags);
     }
 
     /**
@@ -393,13 +437,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void count(final String aspect, final long delta, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(delta)
-                      .append("|c")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, delta, "c", tags);
     }
 
     /**
@@ -407,17 +445,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void count(final String aspect, final long delta, final double sampleRate, final String...tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(delta)
-                      .append("|c|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, delta, "c", sampleRate, tags);
     }
 
     /**
@@ -434,13 +462,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void count(final String aspect, final double delta, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(delta))
-                      .append("|c")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, delta, "c", tags);
     }
 
     /**
@@ -448,17 +470,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void count(final String aspect, final double delta, final double sampleRate, final String...tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(delta))
-                      .append("|c|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, delta, "c", sampleRate, tags);
     }
 
     /**
@@ -553,15 +565,15 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordGaugeValue(final String aspect, final double value, final String... tags) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|g")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "g", tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void recordGaugeValue(final String aspect, final double value, final double sampleRate, final String... tags) {
+        send(aspect, value, "g", sampleRate, tags);
     }
 
     /**
@@ -596,13 +608,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordGaugeValue(final String aspect, final long value, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|g")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "g", tags);
     }
 
     /**
@@ -610,17 +616,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordGaugeValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|g|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+    	send(aspect, value, "g", sampleRate, tags);
     }
 
     /**
@@ -670,13 +666,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordExecutionTime(final String aspect, final long timeInMs, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(timeInMs)
-                      .append("|ms")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, timeInMs, "ms", tags);
     }
 
     /**
@@ -684,17 +674,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordExecutionTime(final String aspect, final long timeInMs, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(timeInMs)
-                      .append("|ms|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, timeInMs, "ms", sampleRate, tags);
     }
 
     /**
@@ -727,15 +707,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordHistogramValue(final String aspect, final double value, final String... tags) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|h")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "h", tags);
     }
 
     /**
@@ -743,19 +715,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordHistogramValue(final String aspect, final double value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|h|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "h", sampleRate, tags);
     }
 
     /**
@@ -772,13 +732,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordHistogramValue(final String aspect, final long value, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|h")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "h", tags);
     }
 
     /**
@@ -786,17 +740,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordHistogramValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|h|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "h", sampleRate, tags);
     }
 
     /**
@@ -847,15 +791,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordDistributionValue(final String aspect, final double value, final String... tags) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|d")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "d", tags);
     }
 
     /**
@@ -863,19 +799,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordDistributionValue(final String aspect, final double value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|d|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "d", sampleRate, tags);
     }
 
     /**
@@ -894,13 +818,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordDistributionValue(final String aspect, final long value, final String... tags) {
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|d")
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "d", tags);
     }
 
     /**
@@ -908,19 +826,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordDistributionValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|d|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
+        send(aspect, value, "d", sampleRate, tags);
     }
-
 
     /**
      * Convenience method equivalent to {@link #recordDistributionValue(String, double, String[])}.
@@ -954,9 +861,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         recordDistributionValue(aspect, value, sampleRate, tags);
     }
 
-    private String eventMap(final Event event) {
-        final StringBuilder res = new StringBuilder("");
-
+    private StringBuilder eventMap(final Event event, StringBuilder res) {
         final long millisSinceEpoch = event.getMillisSinceEpoch();
         if (millisSinceEpoch != -1) {
             res.append("|d:").append(millisSinceEpoch / 1000);
@@ -987,7 +892,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             res.append("|s:").append(sourceTypeName);
         }
 
-        return res.toString();
+        return res;
     }
 
     /**
@@ -1007,14 +912,20 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordEvent(final Event event, final String... tags) {
-        final String title = escapeEventString(prefix + event.getTitle());
-        final String text = escapeEventString(event.getText());
-        send(new StringBuilder("_e{").append(title.length()).append(",").append(text.length()).append("}:").append(title)
-                .append("|").append(text).append(eventMap(event)).append(tagString(tags)).toString());
+        statsDProcessor.send(new Message() {
+            @Override public void writeTo(StringBuilder builder) {
+                final String title = escapeEventString(prefix + event.getTitle());
+                final String text = escapeEventString(event.getText());
+                builder.append("_e{").append(title.length()).append(",").append(text.length()).append("}:").append(title)
+                .append("|").append(text);
+                eventMap(event, builder);
+                tagString(tags, builder);
+            }
+        });
         this.telemetry.incrEventsSent(1);
     }
 
-    private String escapeEventString(final String title) {
+    private static String escapeEventString(final String title) {
         return title.replace("\n", "\\n");
     }
 
@@ -1030,7 +941,22 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordServiceCheckRun(final ServiceCheck sc) {
-        send(toStatsDString(sc));
+        statsDProcessor.send(new Message() {
+            @Override public void writeTo(StringBuilder sb) {
+                // see http://docs.datadoghq.com/guides/dogstatsd/#service-checks
+                sb.append("_sc|").append(sc.getName()).append("|").append(sc.getStatus());
+                if (sc.getTimestamp() > 0) {
+                    sb.append("|d:").append(sc.getTimestamp());
+                }
+                if (sc.getHostname() != null) {
+                    sb.append("|h:").append(sc.getHostname());
+                }
+                tagString(sc.getTags(), sb);
+                if (sc.getMessage() != null) {
+                    sb.append("|m:").append(sc.getEscapedMessage());
+                }
+            }
+        });
         this.telemetry.incrServiceChecksSent(1);
     }
 
@@ -1054,23 +980,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
             return tags.add(entityTag);
         }
         return false;
-    }
-
-    private String toStatsDString(final ServiceCheck sc) {
-        // see http://docs.datadoghq.com/guides/dogstatsd/#service-checks
-        final StringBuilder sb = new StringBuilder();
-        sb.append("_sc|").append(sc.getName()).append("|").append(sc.getStatus());
-        if (sc.getTimestamp() > 0) {
-            sb.append("|d:").append(sc.getTimestamp());
-        }
-        if (sc.getHostname() != null) {
-            sb.append("|h:").append(sc.getHostname());
-        }
-        sb.append(tagString(sc.getTags()));
-        if (sc.getMessage() != null) {
-            sb.append("|m:").append(sc.getEscapedMessage());
-        }
-        return sb.toString();
     }
 
     /**
@@ -1105,21 +1014,19 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public void recordSetValue(final String aspect, final String value, final String... tags) {
         // documentation is light, but looking at dogstatsd source, we can send string values
         // here instead of numbers
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(value)
-                      .append("|s")
-                      .append(tagString(tags))
-                      .toString());
+        statsDProcessor.send(new StatsDMessage(aspect, "s", Double.NaN, tags) {
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(value);
+            }
+        });
     }
 
-    private void sendMetric(final String message) {
+    private void sendMetric(final StatsdMessage message) {
         send(message);
         this.telemetry.incrMetricsSent(1);
     }
 
-    private void send(final String message) {
+    private void send(final StatsdMessage message) {
         if (!statsDProcessor.send(message)) {
             this.telemetry.incrPacketDroppedQueue(1);
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -204,6 +204,10 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     The number of sender worker threads submitting buffers to the socket.
      * @param blocking
      *     Blocking or non-blocking implementation for statsd message queue.
+     * @param enableTelemetry
+     *     Should telemetry be enabled for the client.
+     * @param telemetryFlushInterval
+     *     Telemetry flush interval in seconds when the feature is enabled.
      * @throws StatsDClientException
      *     if the client could not be started
      */

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -103,15 +103,23 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * The NumberFormat instances are not threadsafe but are only ever called from
      * the sender thread.
      */
-    private static final NumberFormat NUMBER_FORMATTER = newFormatter();
-    private static final NumberFormat SAMPLE_RATE_FORMATTER = newFormatter();
+    private static final ThreadLocal<NumberFormat> NUMBER_FORMATTER = new ThreadLocal<NumberFormat>() {
+        @Override
+        protected NumberFormat initialValue() {
+            return newFormatter(false);
+        }
+    };
+    private static final ThreadLocal<NumberFormat> SAMPLE_RATE_FORMATTER = new ThreadLocal<NumberFormat>() {
+        @Override
+        protected NumberFormat initialValue() {
+            return newFormatter(true);
+        }
+    };
 
     static {
-        NUMBER_FORMATTER.setMaximumFractionDigits(6);
-        SAMPLE_RATE_FORMATTER.setMinimumFractionDigits(6);
     }
 
-    private static NumberFormat newFormatter() {
+    private static NumberFormat newFormatter(boolean sampler) {
         // Always create the formatter for the US locale in order to avoid this bug:
         // https://github.com/indeedeng/java-dogstatsd-client/issues/3
         NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
@@ -124,7 +132,18 @@ public class NonBlockingStatsDClient implements StatsDClient {
             symbols.setNaN("NaN");
             decimalFormat.setDecimalFormatSymbols(symbols);
         }
+
+        if (sampler) {
+            numberFormatter.setMinimumFractionDigits(6);
+        } else {
+            numberFormatter.setMaximumFractionDigits(6);
+        }
+
         return numberFormatter;
+    }
+
+    private static String format(ThreadLocal<NumberFormat> formatter, double value) {
+        return formatter.get().format(value);
     }
 
     private final String prefix;
@@ -382,7 +401,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             writeValue(builder);
             builder.append('|').append(type);
             if (!Double.isNaN(sampleRate)) {
-                builder.append('|').append('@').append(SAMPLE_RATE_FORMATTER.format(sampleRate));
+                builder.append('|').append('@').append(format(SAMPLE_RATE_FORMATTER, sampleRate));
             }
             tagString(tags, builder);
         }
@@ -396,7 +415,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
             statsDProcessor.send(new StatsDMessage(aspect, type, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
-                    builder.append(NUMBER_FORMATTER.format(value));
+                    builder.append(format(NUMBER_FORMATTER, value));
                 }
             });
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -100,8 +100,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
     };
 
     /**
-     * The NumberFormat instances are not threadsafe but are only ever called from
-     * the sender thread.
+     * The NumberFormat instances are not threadsafe and thus defined as ThreadLocal
+     * for safety.
      */
     private static final ThreadLocal<NumberFormat> NUMBER_FORMATTER = new ThreadLocal<NumberFormat>() {
         @Override
@@ -274,7 +274,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
             String telemetrytags = tagString(new String[]{CLIENT_TRANSPORT_TAG + transportType,
                                                           CLIENT_VERSION_TAG + properties.getProperty("dogstatsd_client_version"),
-                                                          CLIENT_TAG});
+                                                          CLIENT_TAG}, new StringBuilder()).toString();
 
             this.telemetry = new Telemetry(telemetrytags, statsDProcessor);
 
@@ -409,11 +409,23 @@ public class NonBlockingStatsDClient implements StatsDClient {
         protected abstract void writeValue(StringBuilder builder);
     }
 
+
+    private void sendMetric(final Message message) {
+        send(message);
+        this.telemetry.incrMetricsSent(1);
+    }
+
+    private void send(final Message message) {
+        if (!statsDProcessor.send(message)) {
+            this.telemetry.incrPacketDroppedQueue(1);
+        }
+    }
+
     // send double with sample rate
     private void send(String aspect, final double value, String type, double sampleRate, String[] tags) {
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
 
-            statsDProcessor.send(new StatsDMessage(aspect, type, sampleRate, tags) {
+            sendMetric(new StatsDMessage(aspect, type, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
                     builder.append(format(NUMBER_FORMATTER, value));
                 }
@@ -429,7 +441,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     // send long with sample rate
     private void send(String aspect, final long value, String type, double sampleRate, String[] tags) {
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
-            send(new StatsDMessage(aspect, type, sampleRate, tags) {
+            sendMetric(new StatsDMessage(aspect, type, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
                     builder.append(value);
                 }
@@ -777,22 +789,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void histogram(String aspect, double value, String... tags) {
-        recordHistogramValue(aspect, value, tags);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void histogram(String aspect, double value, double sampleRate, String... tags) {
-        recordHistogramValue(aspect, value, sampleRate, tags);
-    }
-
-    /**
      * Records a value for the specified named distribution.
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
@@ -875,22 +871,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void distribution(final String aspect, final long value, final double sampleRate, final String... tags) {
-        recordDistributionValue(aspect, value, sampleRate, tags);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void distribution(String aspect, double value, String... tags) {
-        recordDistributionValue(aspect, value, tags);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void distribution(String aspect, double value, double sampleRate, String... tags) {
         recordDistributionValue(aspect, value, sampleRate, tags);
     }
 
@@ -1052,17 +1032,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 builder.append(value);
             }
         });
-    }
-
-    private void sendMetric(final StatsdMessage message) {
-        send(message);
-        this.telemetry.incrMetricsSent(1);
-    }
-
-    private void send(final StatsdMessage message) {
-        if (!statsDProcessor.send(message)) {
-            this.telemetry.incrPacketDroppedQueue(1);
-        }
     }
 
     private boolean isInvalidSample(double sampleRate) {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1,5 +1,7 @@
 package com.timgroup.statsd;
 
+import com.timgroup.statsd.Message;
+
 import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketOptions;
@@ -22,8 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
-import com.timgroup.statsd.Message;
 
 
 /**
@@ -334,14 +334,14 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * Generate a suffix conveying the given tag list to the client
      */
     static StringBuilder tagString(final String[] tags, final String tagPrefix, final StringBuilder sb) {
-        if(tagPrefix != null) {
+        if (tagPrefix != null) {
             sb.append(tagPrefix);
-            if((tags == null) || (tags.length == 0)) {
+            if ((tags == null) || (tags.length == 0)) {
                 return sb;
             }
             sb.append(',');
         } else {
-            if((tags == null) || (tags.length == 0)) {
+            if ((tags == null) || (tags.length == 0)) {
                 return sb;
             }
             sb.append("|#");
@@ -349,7 +349,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
         for (int n = tags.length - 1; n >= 0; n--) {
             sb.append(tags[n]);
-            if(n > 0) {
+            if (n > 0) {
                 sb.append(',');
             }
         }
@@ -392,7 +392,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send double with sample rate
     private void send(String aspect, final double value, String type, double sampleRate, String[] tags) {
-        if(Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
+        if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
 
             statsDProcessor.send(new StatsDMessage(aspect, type, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
@@ -409,8 +409,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send long with sample rate
     private void send(String aspect, final long value, String type, double sampleRate, String[] tags) {
-        if(Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
-            sendMetric(new StatsDMessage(aspect, type, sampleRate, tags) {
+        if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
+            send(new StatsDMessage(aspect, type, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
                     builder.append(value);
                 }
@@ -598,7 +598,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordGaugeValue(final String aspect, final long value, final double sampleRate, final String... tags) {
-    	send(aspect, value, "g", sampleRate, tags);
+        send(aspect, value, "g", sampleRate, tags);
     }
 
     /**
@@ -761,7 +761,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * {@inheritDoc}
      */
     @Override
-    public void histogram(String aspect, double value, String... tags){
+    public void histogram(String aspect, double value, String... tags) {
         recordHistogramValue(aspect, value, tags);
     }
 
@@ -769,7 +769,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * {@inheritDoc}
      */
     @Override
-    public void histogram(String aspect, double value, double sampleRate, String... tags){
+    public void histogram(String aspect, double value, double sampleRate, String... tags) {
         recordHistogramValue(aspect, value, sampleRate, tags);
     }
 
@@ -863,7 +863,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * {@inheritDoc}
      */
     @Override
-    public void distribution(String aspect, double value, String... tags){
+    public void distribution(String aspect, double value, String... tags) {
         recordDistributionValue(aspect, value, tags);
     }
 
@@ -871,7 +871,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * {@inheritDoc}
      */
     @Override
-    public void distribution(String aspect, double value, double sampleRate, String... tags){
+    public void distribution(String aspect, double value, double sampleRate, String... tags) {
         recordDistributionValue(aspect, value, sampleRate, tags);
     }
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -577,24 +577,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void recordGaugeValue(final String aspect, final double value, final double sampleRate, final String... tags) {
-        if (isInvalidSample(sampleRate)) {
-            return;
-        }
-        sendMetric(new StringBuilder(prefix)
-                      .append(aspect)
-                      .append(":")
-                      .append(NUMBER_FORMATTERS.get().format(value))
-                      .append("|g|@")
-                      .append(SAMPLE_RATE_FORMATTERS.get().format(sampleRate))
-                      .append(tagString(tags))
-                      .toString());
-    }
-
-    /**
      * Records the latest fixed value for the specified named gauge.
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
@@ -776,6 +758,22 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void histogram(String aspect, double value, String... tags){
+        recordHistogramValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void histogram(String aspect, double value, double sampleRate, String... tags){
+        recordHistogramValue(aspect, value, sampleRate, tags);
+    }
+
+    /**
      * Records a value for the specified named distribution.
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
@@ -858,6 +856,22 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void distribution(final String aspect, final long value, final double sampleRate, final String... tags) {
+        recordDistributionValue(aspect, value, sampleRate, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void distribution(String aspect, double value, String... tags){
+        recordDistributionValue(aspect, value, tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void distribution(String aspect, double value, double sampleRate, String... tags){
         recordDistributionValue(aspect, value, sampleRate, tags);
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -36,7 +36,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                     }
 
                     final Message message = messages.poll(WAIT_SLEEP_MS, TimeUnit.MILLISECONDS);
-                    // TODO: revisit this logic - cleanup, remove duplicate code.
                     if (message != null) {
 
                         builder.setLength(0);
@@ -66,7 +65,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                             writeBuilderToSendBuffer(sendBuffer);
                         }
 
-                        // TODO: revisit this logic
                         if (null == messages.peek()) {
                             outboundQueue.put(sendBuffer);
                             sendBuffer = bufferPool.borrow();

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -2,6 +2,7 @@ package com.timgroup.statsd;
 
 import com.timgroup.statsd.Message;
 
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -12,16 +13,97 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
 
     private final BlockingQueue<Message> messages;
 
+    private class ProcessingTask implements Runnable {
+        private final int id;
+
+        ProcessingTask(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public void run() {
+            boolean empty;
+            ByteBuffer sendBuffer;
+            StringBuilder builder = builders.get(id);
+
+            try {
+                sendBuffer = bufferPool.borrow();
+            } catch (final InterruptedException e) {
+                handler.handle(e);
+                return;
+            }
+
+            while (!(messages.isEmpty() && shutdown)) {
+
+                try {
+
+                    if (Thread.interrupted()) {
+                        return;
+                    }
+
+                    final Message message = messages.poll(WAIT_SLEEP_MS, TimeUnit.MILLISECONDS);
+                    // TODO: revisit this logic - cleanup, remove duplicate code.
+                    if (message != null) {
+
+                        builder.setLength(0);
+
+                        message.writeTo(builder);
+                        int lowerBoundSize = builder.length();
+
+                        // if (sendBuffer.capacity() < data.length) {
+                        //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
+                        // }
+
+                        if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                        }
+
+                        sendBuffer.mark();
+                        if (sendBuffer.position() > 0) {
+                            sendBuffer.put((byte) '\n');
+                        }
+
+                        try {
+                            writeBuilderToSendBuffer(id, builder, sendBuffer);
+                        } catch (BufferOverflowException boe) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                            writeBuilderToSendBuffer(id, builder, sendBuffer);
+                        }
+
+                        // TODO: revisit this logic
+                        if (null == messages.peek()) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                        }
+                    }
+                } catch (final InterruptedException e) {
+                    if (shutdown) {
+                        endSignal.countDown();
+                        return;
+                    }
+                } catch (final Exception e) {
+                    handler.handle(e);
+                }
+            }
+
+            builder.setLength(0);
+            builder.trimToSize();
+            endSignal.countDown();
+        }
+    }
+
     StatsDBlockingProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int poolSize, final int workers)
             throws Exception {
 
         super(queueSize, handler, maxPacketSizeBytes, poolSize, workers);
-        this.messages = new ArrayBlockingQueue<String>(queueSize);
+        this.messages = new ArrayBlockingQueue<>(queueSize);
     }
 
     @Override
-    boolean send(final Message message);
+    boolean send(final Message message){
         try {
             if (!shutdown) {
                 messages.put(message);
@@ -38,80 +120,7 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
     public void run() {
 
         for (int i = 0 ; i < workers ; i++) {
-            executor.submit(new Runnable() {
-                public void run() {
-                    boolean empty;
-                    ByteBuffer sendBuffer;
-                    StringBuilder builder = new StringBuilder();
-                    CharBuffer charBuffer = CharBuffer.wrap(builder);
-
-                    try {
-                        sendBuffer = bufferPool.borrow();
-                    } catch (final InterruptedException e) {
-                        handler.handle(e);
-                        return;
-                    }
-
-                    while (!(messages.isEmpty() && shutdown)) {
-
-                        try {
-
-                            if (Thread.interrupted()) {
-                                return;
-                            }
-
-                            final Message message = messages.poll(WAIT_SLEEP_MS, TimeUnit.MILLISECONDS);
-                            // TODO: revisit this logic - cleanup, remove duplicate code.
-                            if (message != null) {
-
-                                builder.setLength(0);
-
-                                message.writeTo(builder);
-                                int lowerBoundSize = builder.length();
-
-                                // if (sendBuffer.capacity() < data.length) {
-                                //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
-                                // }
-
-                                if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                }
-
-                                sendBuffer.mark();
-                                if (sendBuffer.position() > 0) {
-                                    sendBuffer.put((byte) '\n');
-                                }
-
-                                try {
-                                    charBuffer = writeBuilderToSendBuffer(builder, charBuffer, sendBuffer);
-                                } catch (BufferOverflowException boe) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                    charBuffer = writeBuilderToSendBuffer(builder, charBuffer, sendBuffer);
-                                }
-
-                                // TODO: revisit this logic
-                                if (null == messages.peek()) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                }
-                            }
-                        } catch (final InterruptedException e) {
-                            if (shutdown) {
-                                endSignal.countDown();
-                                return;
-                            }
-                        } catch (final Exception e) {
-                            handler.handle(e);
-                        }
-                    }
-
-                    builder.setLength(0);
-                    builder.trimToSize();
-                    endSignal.countDown();
-                }
-            });
+            executor.submit(new ProcessingTask(i));
         }
 
         boolean done = false;

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -4,10 +4,10 @@ import com.timgroup.statsd.Message;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+
 
 public class StatsDBlockingProcessor extends StatsDProcessor {
 
@@ -44,9 +44,9 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                         message.writeTo(builder);
                         int lowerBoundSize = builder.length();
 
-                        // if (sendBuffer.capacity() < data.length) {
-                        //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
-                        // }
+                        if (sendBuffer.capacity() < lowerBoundSize) {
+                            throw new InvalidMessageException(MESSAGE_TOO_LONG, builder.toString());
+                        }
 
                         if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
                             outboundQueue.put(sendBuffer);
@@ -103,7 +103,7 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
     }
 
     @Override
-    protected boolean send(final Message message){
+    protected boolean send(final Message message) {
         try {
             if (!shutdown) {
                 messages.put(message);

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -27,13 +27,9 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                 return;
             }
 
-            while (!(messages.isEmpty() && shutdown)) {
+            while (!(shutdown && messages.isEmpty())) {
 
                 try {
-
-                    if (Thread.interrupted()) {
-                        return;
-                    }
 
                     final Message message = messages.poll(WAIT_SLEEP_MS, TimeUnit.MILLISECONDS);
                     if (message != null) {
@@ -112,23 +108,5 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
         }
 
         return false;
-    }
-
-    @Override
-    public void run() {
-
-        for (int i = 0 ; i < workers ; i++) {
-            executor.submit(createProcessingTask());
-        }
-
-        boolean done = false;
-        while (!done) {
-            try {
-                endSignal.await();
-                done = true;
-            } catch (final InterruptedException e) {
-                // NOTHING
-            }
-        }
     }
 }

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -2,6 +2,7 @@ package com.timgroup.statsd;
 
 import com.timgroup.statsd.Message;
 
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
 import java.util.Queue;
@@ -14,6 +15,91 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     private final int qcapacity;
     private final AtomicInteger qsize;  // qSize will not reflect actual size, but a close estimate.
 
+    private class ProcessingTask implements Runnable {
+        private final int id;
+
+        ProcessingTask(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public void run() {
+            boolean empty;
+            ByteBuffer sendBuffer;
+            StringBuilder builder = builders.get(id);
+
+            try {
+                sendBuffer = bufferPool.borrow();
+            } catch (final InterruptedException e) {
+                handler.handle(e);
+                return;
+            }
+
+            while (!((empty = messages.isEmpty()) && shutdown)) {
+
+                try {
+                    if (empty) {
+                        Thread.sleep(WAIT_SLEEP_MS);
+                        continue;
+                    }
+
+                    if (Thread.interrupted()) {
+                        return;
+                    }
+                    final Message message = messages.poll();
+                    // TODO: revisit this logic - cleanup, remove duplicate code.
+                    if (message != null) {
+
+                        qsize.decrementAndGet();
+                        builder.setLength(0);
+
+                        message.writeTo(builder);
+                        int lowerBoundSize = builder.length();
+
+                        // if (sendBuffer.capacity() < data.length) {
+                        //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
+                        // }
+
+                        if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                        }
+
+                        sendBuffer.mark();
+                        if (sendBuffer.position() > 0) {
+                            sendBuffer.put((byte) '\n');
+                        }
+
+                        try {
+                            writeBuilderToSendBuffer(id, builder, sendBuffer);
+                        } catch (BufferOverflowException boe) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                            writeBuilderToSendBuffer(id, builder, sendBuffer);
+                        }
+
+                        // TODO: revisit this logic
+                        if (null == messages.peek()) {
+                            outboundQueue.put(sendBuffer);
+                            sendBuffer = bufferPool.borrow();
+                        }
+                    }
+                } catch (final InterruptedException e) {
+                    if (shutdown) {
+                        endSignal.countDown();
+                        return;
+                    }
+                } catch (final Exception e) {
+                    handler.handle(e);
+                }
+            }
+
+            builder.setLength(0);
+            builder.trimToSize();
+            endSignal.countDown();
+        }
+    }
+
     StatsDNonBlockingProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int poolSize, final int workers)
             throws Exception {
@@ -21,11 +107,11 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
         super(queueSize, handler, maxPacketSizeBytes, poolSize, workers);
         this.qsize = new AtomicInteger(0);
         this.qcapacity = queueSize;
-        this.messages = new ConcurrentLinkedQueue<String>();
+        this.messages = new ConcurrentLinkedQueue<>();
     }
 
     @Override
-    boolean send(final Message message);
+    boolean send(final Message message){
         if (!shutdown) {
             if (qsize.get() < qcapacity) {
                 messages.offer(message);
@@ -41,84 +127,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     public void run() {
 
         for (int i = 0 ; i < workers ; i++) {
-            executor.submit(new Runnable() {
-                public void run() {
-                    boolean empty;
-                    ByteBuffer sendBuffer;
-                    StringBuilder builder = new StringBuilder();
-                    CharBuffer charBuffer = CharBuffer.wrap(builder);
-
-                    try {
-                        sendBuffer = bufferPool.borrow();
-                    } catch (final InterruptedException e) {
-                        handler.handle(e);
-                        return;
-                    }
-
-                    while (!((empty = messages.isEmpty()) && shutdown)) {
-
-                        try {
-                            if (empty) {
-                                Thread.sleep(WAIT_SLEEP_MS);
-                                continue;
-                            }
-
-                            if (Thread.interrupted()) {
-                                return;
-                            }
-                            final String message = messages.poll();
-                            // TODO: revisit this logic - cleanup, remove duplicate code.
-                            if (message != null) {
-
-                                qsize.decrementAndGet();
-                                builder.setLength(0);
-
-                                message.writeTo(builder);
-                                int lowerBoundSize = builder.length();
-
-                                // if (sendBuffer.capacity() < data.length) {
-                                //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
-                                // }
-
-                                if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                }
-
-                                sendBuffer.mark();
-                                if (sendBuffer.position() > 0) {
-                                    sendBuffer.put((byte) '\n');
-                                }
-
-                                try {
-                                    charBuffer = writeBuilderToSendBuffer(builder, charBuffer, sendBuffer);
-                                } catch (BufferOverflowException boe) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                    charBuffer = writeBuilderToSendBuffer(builder, charBuffer, sendBuffer);
-                                }
-
-                                // TODO: revisit this logic
-                                if (null == messages.peek()) {
-                                    outboundQueue.put(sendBuffer);
-                                    sendBuffer = bufferPool.borrow();
-                                }
-                            }
-                        } catch (final InterruptedException e) {
-                            if (shutdown) {
-                                endSignal.countDown();
-                                return;
-                            }
-                        } catch (final Exception e) {
-                            handler.handle(e);
-                        }
-                    }
-
-                    builder.setLength(0);
-                    builder.trimToSize();
-                    endSignal.countDown();
-                }
-            });
+            executor.submit(new ProcessingTask(i));
         }
 
         boolean done = false;

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -4,10 +4,10 @@ import com.timgroup.statsd.Message;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+
 
 public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
@@ -50,9 +50,9 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                         message.writeTo(builder);
                         int lowerBoundSize = builder.length();
 
-                        // if (sendBuffer.capacity() < data.length) {
-                        //     throw new InvalidMessageException(MESSAGE_TOO_LONG, message);
-                        // }
+                        if (sendBuffer.capacity() < lowerBoundSize) {
+                            throw new InvalidMessageException(MESSAGE_TOO_LONG, builder.toString());
+                        }
 
                         if (sendBuffer.remaining() < (lowerBoundSize + 1)) {
                             outboundQueue.put(sendBuffer);
@@ -110,7 +110,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     }
 
     @Override
-    protected boolean send(final Message message){
+    protected boolean send(final Message message) {
         if (!shutdown) {
             if (qsize.get() < qcapacity) {
                 messages.offer(message);

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -41,7 +41,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                         return;
                     }
                     final Message message = messages.poll();
-                    // TODO: revisit this logic - cleanup, remove duplicate code.
                     if (message != null) {
 
                         qsize.decrementAndGet();
@@ -72,7 +71,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                             writeBuilderToSendBuffer(sendBuffer);
                         }
 
-                        // TODO: revisit this logic
                         if (null == messages.peek()) {
                             outboundQueue.put(sendBuffer);
                             sendBuffer = bufferPool.borrow();

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -120,24 +120,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
         return false;
     }
 
-    @Override
-    public void run() {
-
-        for (int i = 0 ; i < workers ; i++) {
-            executor.submit(createProcessingTask());
-        }
-
-        boolean done = false;
-        while (!done) {
-            try {
-                endSignal.await();
-                done = true;
-            } catch (final InterruptedException e) {
-                // NOTHING
-            }
-        }
-    }
-
     boolean isShutdown() {
         return shutdown;
     }

--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -80,7 +80,7 @@ public abstract class StatsDProcessor implements Runnable {
 
         this.builders = new ArrayList<>(workers);
         this.charBuffers = new ArrayList<>(workers);
-        for(int i=0; i<workers ; i++) {
+        for (int i = 0 ; i < workers ; i++) {
             StringBuilder builder = new StringBuilder();
             CharBuffer buffer = CharBuffer.wrap(builder);
             builders.add(builder);

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -4,12 +4,8 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
-import java.nio.charset.Charset;
-
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -79,6 +79,9 @@ public class Telemetry {
 
     /**
      * Startsthe flush timer for the telemetry.
+     *
+     * @param flushInterval
+     *     Telemetry flush interval in seconds.
      */
     public void start(final long flushInterval) {
         // flush the telemetry at regualar interval

--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -8,6 +8,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixSocketAddress;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -3,11 +3,11 @@ package com.timgroup.statsd;
 
 import java.io.IOException;
 import java.net.SocketException;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import java.util.Random;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -64,6 +64,9 @@ public final class NonBlockingStatsDClientPerfTest {
                 Thread.sleep(50);
             } catch (InterruptedException ex) {}
         }
+
+        log.info("Messages at server: " + messages);
+        log.info("Packets at server: " + server.packetsReceived());
 
         assertEquals(testSize, server.messagesReceived().size());
     }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
+import com.timgroup.statsd.StatsDSender.Message;
+
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.List;

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-import com.timgroup.statsd.StatsDSender.Message;
+import com.timgroup.statsd.Message;
 
 import java.io.IOException;
 import java.net.SocketAddress;

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -774,6 +774,7 @@ public class NonBlockingStatsDClientTest {
             final Exception exception = exceptions.get(0);
             assertEquals(InvalidMessageException.class, exception.getClass());
             assertTrue(((InvalidMessageException)exception).getInvalidMessage().startsWith("_sc|toolong|"));
+            // assertEquals(BufferOverflowException.class, exception.getClass());
 
             final List<String> messages = server.messagesReceived();
             assertEquals(1, messages.size());

--- a/src/test/java/com/timgroup/statsd/RecordingErrorHandler.java
+++ b/src/test/java/com/timgroup/statsd/RecordingErrorHandler.java
@@ -1,13 +1,16 @@
 package com.timgroup.statsd;
 
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.List;
+import java.util.Queue;
+
 
 /**
  * @author Taylor Schilling
  */
 public class RecordingErrorHandler implements StatsDClientErrorHandler {
-    private final List<Exception> exceptions = new ArrayList<Exception>();
+    private final Queue<Exception> exceptions = new ConcurrentLinkedQueue<>();
 
     @Override
     public void handle(final Exception exception) {
@@ -15,6 +18,6 @@ public class RecordingErrorHandler implements StatsDClientErrorHandler {
     }
 
     public List<Exception> getExceptions() {
-        return exceptions;
+        return new ArrayList(exceptions);
     }
 }


### PR DESCRIPTION
This is an adaptation of #74 by @njhill by which we take the same principles and apply them to the new client architecture to reduce the overhead of allocations on the client, and consequently on the client application.

Still WIP - a couple of things went wrong after a rebase, so a few things still pending fixes.