### PR TITLE
[telemetry] allow a different remote destination for telemetry stats

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -315,13 +315,13 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
             this.telemetry = new Telemetry(telemetrytags, telemetryStatsDProcessor);
 
-            statsDSender = createSender(addressLookup, handler, telemetryClientChannel, statsDProcessor.getBufferPool(),
+            statsDSender = createSender(addressLookup, handler, clientChannel, statsDProcessor.getBufferPool(),
                     statsDProcessor.getOutboundQueue(), senderWorkers, this.telemetry);
 
             telemetryStatsDSender = statsDSender;
             if (telemetryStatsDProcessor != statsDProcessor) {
                 // TODO: figure out why the hell telemetryClientChannel does not work here!
-                telemetryStatsDSender = createSender(telemetryAddressLookup, handler, clientChannel,
+                telemetryStatsDSender = createSender(telemetryAddressLookup, handler, telemetryClientChannel,
                         telemetryStatsDProcessor.getBufferPool(), telemetryStatsDProcessor.getOutboundQueue(),
                         1, this.telemetry);
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -211,9 +211,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * @param blocking
      *     Blocking or non-blocking implementation for statsd message queue.
      * @param enableTelemetry
-     *     Should telemetry be enabled for the client.
+     *     Boolean to enable client telemetry.
      * @param telemetryFlushInterval
-     *     Telemetry flush interval in seconds when the feature is enabled.
+     *     Telemetry flush interval integer, in milliseconds.
      * @throws StatsDClientException
      *     if the client could not be started
      */

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -161,8 +161,12 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
     });
 
+    // Typically the telemetry and regular processors will be the same,
+    // but a separate destination for telemetry is supported.
     protected final StatsDProcessor statsDProcessor;
+    protected StatsDProcessor telemetryStatsDProcessor;
     protected final StatsDSender statsDSender;
+    protected StatsDSender telemetryStatsDSender;
     protected final Telemetry telemetry;
 
     /**
@@ -184,6 +188,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     handler to use when an exception occurs during usage, may be null to indicate noop
      * @param addressLookup
      *     yields the IP address and socket of the StatsD server
+     * @param telemetryAddressLookup
+     *     yields the IP address and socket of the StatsD telemetry server destination
      * @param queueSize
      *     the maximum amount of unprocessed messages in the Queue.
      * @param timeout
@@ -212,11 +218,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     if the client could not be started
      */
     public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags,
-                                   final StatsDClientErrorHandler errorHandler, Callable<SocketAddress> addressLookup,
-                                   final int timeout, final int bufferSize, final int maxPacketSizeBytes,
-                                   String entityID, final int poolSize, final int processorWorkers,
-                                   final int senderWorkers, boolean blocking, final boolean enableTelemetry,
-                                   final int telemetryFlushInterval)
+            final StatsDClientErrorHandler errorHandler, Callable<SocketAddress> addressLookup,
+            Callable<SocketAddress> telemetryAddressLookup, final int timeout, final int bufferSize,
+            final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
+            final int senderWorkers, boolean blocking, final boolean enableTelemetry,
+            final int telemetryFlushInterval)
             throws StatsDClientException {
         if ((prefix != null) && (!prefix.isEmpty())) {
             this.prefix = prefix + ".";
@@ -273,6 +279,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             }
 
             statsDProcessor = createProcessor(queueSize, handler, maxPacketSizeBytes, poolSize, processorWorkers, blocking);
+            telemetryStatsDProcessor = statsDProcessor;
 
             Properties properties = new Properties();
             properties.load(getClass().getClassLoader().getResourceAsStream("version.properties"));
@@ -281,10 +288,40 @@ public class NonBlockingStatsDClient implements StatsDClient {
                                                           CLIENT_VERSION_TAG + properties.getProperty("dogstatsd_client_version"),
                                                           CLIENT_TAG}, new StringBuilder()).toString();
 
-            this.telemetry = new Telemetry(telemetrytags, statsDProcessor);
+            if (addressLookup != telemetryAddressLookup) {
+                DatagramChannel telemetryClientChannel;
 
-            statsDSender = createSender(addressLookup, handler, clientChannel,
-                    statsDProcessor.getBufferPool(), statsDProcessor.getOutboundQueue(), senderWorkers, this.telemetry);
+                final SocketAddress telemetryAddress = addressLookup.call();
+                if (telemetryAddress instanceof UnixSocketAddress) {
+                    telemetryClientChannel = UnixDatagramChannel.open();
+                    // Set send timeout, to handle the case where the transmission buffer is full
+                    // If no timeout is set, the send becomes blocking
+                    if (timeout > 0) {
+                        telemetryClientChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
+                    }
+                    if (bufferSize > 0) {
+                        telemetryClientChannel.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
+                    }
+                } else {
+                    telemetryClientChannel = DatagramChannel.open();
+                }
+
+                // similar settings, but a single worker and non-blocking.
+                telemetryStatsDProcessor = createProcessor(queueSize, handler, maxPacketSizeBytes,
+                        poolSize, 1, false);
+            }
+
+            this.telemetry = new Telemetry(telemetrytags, telemetryStatsDProcessor);
+
+            statsDSender = createSender(addressLookup, handler, clientChannel, statsDProcessor.getBufferPool(),
+                    statsDProcessor.getOutboundQueue(), senderWorkers, this.telemetry);
+            telemetryStatsDSender = statsDSender;
+
+            if (telemetryStatsDProcessor != statsDProcessor) {
+                telemetryStatsDSender = createSender(addressLookup, handler, clientChannel,
+                        telemetryStatsDProcessor.getBufferPool(), telemetryStatsDProcessor.getOutboundQueue(),
+                        1, this.telemetry);
+            }
 
         } catch (final Exception e) {
             throw new StatsDClientException("Failed to start StatsD client", e);
@@ -858,6 +895,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     yields the IP address and socket of the StatsD server
      * @param queueSize
      *     the maximum amount of unprocessed messages in the BlockingQueue.
+     *     the maximum amount of unprocessed messages in the Queue.
      * @param timeout
      *     the timeout in milliseconds for blocking operations. Applies to unix sockets only.
      * @param bufferSize
@@ -881,6 +919,64 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .socketBufferSize(bufferSize)
             .maxPacketSizeBytes(maxPacketSizeBytes)
             .build());
+    }
+
+    /**
+     * Create a new StatsD client communicating with a StatsD instance on the
+     * specified host and port. All messages send via this client will have
+     * their keys prefixed with the specified string. The new client will
+     * attempt to open a connection to the StatsD server immediately upon
+     * instantiation, and may throw an exception if that a connection cannot
+     * be established. Once a client has been instantiated in this way, all
+     * exceptions thrown during subsequent usage are passed to the specified
+     * handler and then consumed, guaranteeing that failures in metrics will
+     * not affect normal code execution.
+     *
+     * @param prefix
+     *     the prefix to apply to keys sent via this client
+     * @param constantTags
+     *     tags to be added to all content sent
+     * @param errorHandler
+     *     handler to use when an exception occurs during usage, may be null to indicate noop
+     * @param addressLookup
+     *     yields the IP address and socket of the StatsD server
+     * @param queueSize
+     *     the maximum amount of unprocessed messages in the BlockingQueue.
+     *     the maximum amount of unprocessed messages in the Queue.
+     * @param timeout
+     *     the timeout in milliseconds for blocking operations. Applies to unix sockets only.
+     * @param bufferSize
+     *     the socket buffer size in bytes. Applies to unix sockets only.
+     * @param maxPacketSizeBytes
+     *     the maximum number of bytes for a message that can be sent
+     * @param entityID
+     *     the entity id value used with an internal tag for tracking client entity.
+     *     If "entityID=null" the client default the value with the environment variable "DD_ENTITY_ID".
+     *     If the environment variable is not defined, the internal tag is not added.
+     * @param poolSize
+     *     The size for the network buffer pool.
+     * @param processorWorkers
+     *     The number of processor worker threads assembling buffers for submission.
+     * @param senderWorkers
+     *     The number of sender worker threads submitting buffers to the socket.
+     * @param blocking
+     *     Blocking or non-blocking implementation for statsd message queue.
+     * @param enableTelemetry
+     *     Should telemetry be enabled for the client.
+     * @param telemetryFlushInterval
+     *     Telemetry flush interval in seconds when the feature is enabled.
+     * @throws StatsDClientException
+     *     if the client could not be started
+     */
+    public NonBlockingStatsDClient(final String prefix, final int queueSize, String[] constantTags,
+            final StatsDClientErrorHandler errorHandler, Callable<SocketAddress> addressLookup,
+            final int timeout, final int bufferSize, final int maxPacketSizeBytes, String entityID,
+            final int poolSize, final int processorWorkers, final int senderWorkers, boolean blocking,
+            final boolean enableTelemetry, final int telemetryFlushInterval) throws StatsDClientException {
+
+        this(prefix, queueSize, constantTags, errorHandler, addressLookup, addressLookup, timeout,
+                bufferSize, maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers,
+                blocking, enableTelemetry, telemetryFlushInterval);
     }
 
     protected StatsDProcessor createProcessor(final int queueSize, final StatsDClientErrorHandler handler,

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -160,7 +160,6 @@ public class NonBlockingStatsDClientBuilder {
             } else {
                 telemetryLookup = staticStatsDAddressResolution(telemetryHostname, telemetryPort);
             }
-            System.out.println("IN CLIENT, configured telemetry " + telemetryLookup);
         }
 
         return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -148,7 +148,7 @@ public class NonBlockingStatsDClientBuilder {
      */
     public NonBlockingStatsDClient build() throws StatsDClientException {
         Callable<SocketAddress> lookup = addressLookup;
-        Callable<SocketAddress> telemetryLookup = null;
+        Callable<SocketAddress> telemetryLookup = telemetryAddressLookup;
 
         if (lookup == null) {
             lookup = staticStatsDAddressResolution(hostname, port);

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -17,6 +17,7 @@ public class NonBlockingStatsDClientBuilder {
      */
 
     public int port = NonBlockingStatsDClient.DEFAULT_DOGSTATSD_PORT;
+    public int telemetryPort = NonBlockingStatsDClient.DEFAULT_DOGSTATSD_PORT;
     public int queueSize = NonBlockingStatsDClient.DEFAULT_QUEUE_SIZE;
     public int timeout = NonBlockingStatsDClient.SOCKET_TIMEOUT_MS;
     public int bufferPoolSize = NonBlockingStatsDClient.DEFAULT_POOL_SIZE;
@@ -29,8 +30,10 @@ public class NonBlockingStatsDClientBuilder {
     public boolean blocking;
 
     public Callable<SocketAddress> addressLookup;
+    public Callable<SocketAddress> telemetryAddressLookup;
 
     public String hostname;
+    public String telemetryHostname;
     public String prefix;
     public String entityID;
     public String[] constantTags;
@@ -41,6 +44,11 @@ public class NonBlockingStatsDClientBuilder {
 
     public NonBlockingStatsDClientBuilder port(int val) {
         port = val;
+        return this;
+    }
+
+    public NonBlockingStatsDClientBuilder telemetryPort(int val) {
+        telemetryPort = val;
         return this;
     }
 
@@ -89,8 +97,18 @@ public class NonBlockingStatsDClientBuilder {
         return this;
     }
 
+    public NonBlockingStatsDClientBuilder telemetryAddressLookup(Callable<SocketAddress> val) {
+        telemetryAddressLookup = val;
+        return this;
+    }
+
     public NonBlockingStatsDClientBuilder hostname(String val) {
         hostname = val;
+        return this;
+    }
+
+    public NonBlockingStatsDClientBuilder telemetryHostname(String val) {
+        telemetryHostname = val;
         return this;
     }
 
@@ -129,17 +147,26 @@ public class NonBlockingStatsDClientBuilder {
      * @return the built NonBlockingStatsDClient.
      */
     public NonBlockingStatsDClient build() throws StatsDClientException {
-        if (addressLookup != null) {
-            return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,
-                    addressLookup, timeout, socketBufferSize, maxPacketSizeBytes, entityID,
-                    bufferPoolSize, processorWorkers, senderWorkers, blocking, enableTelemetry,
-                    telemetryFlushInterval);
-        } else {
-            return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,
-                    staticStatsDAddressResolution(hostname, port), timeout, socketBufferSize, maxPacketSizeBytes,
-                    entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking, enableTelemetry,
-                    telemetryFlushInterval);
+        Callable<SocketAddress> lookup = addressLookup;
+        Callable<SocketAddress> telemetryLookup = null;
+
+        if (lookup == null) {
+            lookup = staticStatsDAddressResolution(hostname, port);
         }
+
+        if (telemetryLookup == null) {
+            if (telemetryHostname == null) {
+                telemetryLookup = lookup;
+            } else {
+                telemetryLookup = staticStatsDAddressResolution(telemetryHostname, telemetryPort);
+            }
+            System.out.println("IN CLIENT, configured telemetry " + telemetryLookup);
+        }
+
+        return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,
+                lookup, telemetryLookup, timeout, socketBufferSize, maxPacketSizeBytes,
+                entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking,
+                enableTelemetry, telemetryFlushInterval);
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -48,6 +48,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                         message.writeTo(builder);
                         int lowerBoundSize = builder.length();
 
+
                         if (sendBuffer.capacity() < lowerBoundSize) {
                             throw new InvalidMessageException(MESSAGE_TOO_LONG, builder.toString());
                         }

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -81,7 +81,7 @@ public class Telemetry {
      * Startsthe flush timer for the telemetry.
      *
      * @param flushInterval
-     *     Telemetry flush interval in seconds.
+     *     Telemetry flush interval, in milliseconds.
      */
     public void start(final long flushInterval) {
         // flush the telemetry at regualar interval

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -951,8 +951,9 @@ public class NonBlockingStatsDClientTest {
                 Callable<SocketAddress> addressLookup, final int timeout, final int bufferSize,
                 final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
                 final int senderWorkers, boolean blocking) throws StatsDClientException {
-            super(prefix, queueSize, constantTags, errorHandler, addressLookup, timeout, bufferSize, maxPacketSizeBytes,
-                    entityID, poolSize, processorWorkers, senderWorkers, blocking, false, 0);
+
+            super(prefix, queueSize, constantTags, errorHandler, addressLookup, addressLookup, timeout,bufferSize,
+                    maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers, blocking, false, 0);
             lock = new CountDownLatch(1);
         }
 

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -85,9 +85,9 @@ public class TelemetryTest {
                                        final int senderWorkers, boolean blocking, final boolean enableTelemetry,
                                        final int telemetryFlushInterval)
                 throws StatsDClientException {
-                super(prefix, queueSize, constantTags, errorHandler, addressLookup, timeout, bufferSize,
-                        maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers, blocking,
-                        enableTelemetry, telemetryFlushInterval);
+                super(prefix, queueSize, constantTags, errorHandler, addressLookup, addressLookup, timeout,
+                        bufferSize, maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers,
+                        blocking, enableTelemetry, telemetryFlushInterval);
         }
     };
 


### PR DESCRIPTION
This is useful for testing, will typically be unused by customers.