### PR TITLE
[Documentation Update] Container Specific Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ public class DogStatsdClient {
 
 See the full list of available [DogStatsD Client instantiation parameters](https://docs.datadoghq.com/developers/dogstatsd/?tab=java#client-instantiation-parameters).
 
+### Origin detection over UDP and UDS
+
+Origin detection is a method to detect which pod `DogStatsD` packets are coming from in order to add the pod's tags to the tag list.
+The `DogStatsD` client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable if found, which is the pod's UID. The Datadog Agent uses this tag to add container tags to the metrics. To avoid overwriting this global tag, make sure to only `append` to the `constant_tags` list.
+
+To enable origin detection over UDP, add the following lines to your application manifest
+```yaml
+env:
+  - name: DD_ENTITY_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+```
+
+
 ## Usage
 
 In order to use DogStatsD metrics, events, and Service Checks the Agent must be [running and available](https://docs.datadoghq.com/developers/dogstatsd/?tab=java).


### PR DESCRIPTION
Add documentation update to show how to configure statsd client such that metrics generated inherit pod specific tags -- based on what we see in [python's client](https://github.com/DataDog/datadogpy#origin-detection-over-udp)

[ENV variable](https://github.com/DataDog/java-dogstatsd-client/blob/28055c0b836990debd110860f19d7a7f1a335eb6/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L61) lines up