### PR TITLE
Updated version in README to latest published one

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The client jar is distributed via Maven central, and can be downloaded [from Mav
 <dependency>
     <groupId>com.datadoghq</groupId>
     <artifactId>java-dogstatsd-client</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The current README is misleading as `2.9.0` does not have the `NonBlockingStatsDClientBuilder` class.

Updating the version reference in the pom.xml example to `2.10.0` makes the README consistent