### PR TITLE
Make Unix Domain Socket functionality optional

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -185,7 +185,12 @@ public class NonBlockingStatsDClientBuilder {
         return new Callable<SocketAddress>() {
             @Override public SocketAddress call() throws UnknownHostException {
                 if (port == 0) { // Hostname is a file path to the socket
-                    return new UnixSocketAddress(hostname);
+                    // Use of reflection to avoid hard dependency on UnixSocketAddress
+                    // Replace original code : "return new UnixSocketAddress(hostname);"
+                    Class<?> clazz = Class.forName("jnr.unixsocket.UnixSocketAddress.UnixSocketAddress");
+                    Constructor<?> ctor = clazz.getConstructor(String.class);
+                    Object object = ctor.newInstance(new Object[]{hostname});
+                    return (SocketAddress) object;
                 } else {
                     return new InetSocketAddress(InetAddress.getByName(hostname), port);
                 }


### PR DESCRIPTION
A try to fix Make Unix Domain Socket functionality optional by using reflection #85 
It's a test to use the full datadog CI.
I use a Draft pull request for the moment.
