### PR TITLE
Update version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client jar is distributed via Maven central, and can be downloaded [from Mav
 <dependency>
     <groupId>com.datadoghq</groupId>
     <artifactId>java-dogstatsd-client</artifactId>
-    <version>2.10.0</version>
+    <version>2.10.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Version 2.10.0 is broken for JDK 8 as described in https://github.com/DataDog/java-dogstatsd-client/issues/112, so we shouldn't be recommending use of that version in the docs.