### PR TITLE
Bump jnr-unixsocket from 0.27 to 0.38.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.27</version>
+      <version>0.38.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
https://github.com/jnr/jnr-unixsocket/compare/jnr-unixsocket-0.27...jnr-unixsocket-0.38.3