### PR TITLE
[processor] shutdown the executor on cue, dont leak

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -124,8 +124,4 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
         return false;
     }
-
-    void shutdown() {
-        shutdown = true;
-    }
 }

--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -151,7 +151,7 @@ public abstract class StatsDProcessor implements Runnable {
     }
 
     void shutdown() {
-        executor.shutdown();
         shutdown = true;
+        executor.shutdown();
     }
 }

--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -147,11 +147,11 @@ public abstract class StatsDProcessor implements Runnable {
     }
 
     boolean isShutdown() {
-        executor.shutdown();
         return shutdown;
     }
 
     void shutdown() {
+        executor.shutdown();
         shutdown = true;
     }
 }


### PR DESCRIPTION
Fixes an issue with the processor shutdown; bad inheritance + previous wrong shutdown of the executor service. 

This bug could range from a non-issue to a thread leak depending on the client application. Apologies for it.