### PR TITLE
[sampling] sampling on counts to be disabled when aggregation is enabled.

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1145,6 +1145,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send double with sample rate
     private void send(String aspect, final double value, Message.Type type, double sampleRate, String[] tags) {
+        if (statsDProcessor.getAggregator().getFlushInterval() != 0
+                && type == Message.Type.COUNT && !Double.isNaN(sampleRate)) {
+            sampleRate = Double.NaN;
+        }
+
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
 
             sendMetric(new StatsDMessage<Double>(aspect, type, Double.valueOf(value), sampleRate, tags) {
@@ -1162,6 +1167,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send long with sample rate
     private void send(String aspect, final long value, Message.Type type, double sampleRate, String[] tags) {
+        if (statsDProcessor.getAggregator().getFlushInterval() != 0
+                && type == Message.Type.COUNT && !Double.isNaN(sampleRate)) {
+            sampleRate = Double.NaN;
+        }
+
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
             sendMetric(new StatsDMessage<Long>(aspect, type, value, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1145,9 +1145,14 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send double with sample rate
     private void send(String aspect, final double value, Message.Type type, double sampleRate, String[] tags) {
-        if (statsDProcessor.getAggregator().getFlushInterval() != 0
-                && type == Message.Type.COUNT && !Double.isNaN(sampleRate)) {
-            sampleRate = Double.NaN;
+        if (statsDProcessor.getAggregator().getFlushInterval() != 0 && !Double.isNaN(sampleRate)) {
+            switch (type) {
+                case COUNT:
+                    sampleRate = Double.NaN;
+                    break;
+                default:
+                    break;
+            }
         }
 
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
@@ -1167,9 +1172,14 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     // send long with sample rate
     private void send(String aspect, final long value, Message.Type type, double sampleRate, String[] tags) {
-        if (statsDProcessor.getAggregator().getFlushInterval() != 0
-                && type == Message.Type.COUNT && !Double.isNaN(sampleRate)) {
-            sampleRate = Double.NaN;
+        if (statsDProcessor.getAggregator().getFlushInterval() != 0 && !Double.isNaN(sampleRate)) {
+            switch (type) {
+                case COUNT:
+                    sampleRate = Double.NaN;
+                    break;
+                default:
+                    break;
+            }
         }
 
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {


### PR DESCRIPTION
For data consistency, should aggregation be enabled we will disable sampling for counts. This is due to the fact we cannot really guarantee a constant sample rate for any given count, and there keeping track of samples could introduce statistical inconsistencies. 

The main goal of sampling was to reduce traffic on the wire anyhow, and we already achieve this by enabling aggregation so this should come at no ill effects to the user. 