### PR TITLE
[processor] remove overridden method

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -124,8 +124,4 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
         return false;
     }
-
-    void shutdown() {
-        shutdown = true;
-    }
 }


### PR DESCRIPTION
Unfortunately the previous thread leak fix worked on `master` because the unneeded inherited code had already been cleaned up, but the cherry-pick didn't address that detail here. 