### PR TITLE
[messsages] all messages should be EOL terminated

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1126,6 +1126,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 builder.append('|').append('@').append(format(SAMPLE_RATE_FORMATTER, sampleRate));
             }
             tagString(this.tags, builder);
+
+            builder.append('\n');
         }
 
         protected abstract void writeValue(StringBuilder builder);
@@ -1681,6 +1683,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 .append("|").append(text);
                 eventMap(event, builder);
                 tagString(eventTags, builder);
+
+                builder.append('\n');
             }
         });
         this.telemetry.incrEventsSent(1);
@@ -1720,6 +1724,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 if (sc.getMessage() != null) {
                     sb.append("|m:").append(sc.getEscapedMessage());
                 }
+
+                sb.append('\n');
             }
         });
         this.telemetry.incrServiceChecksSent(1);
@@ -1789,6 +1795,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 writeValue(builder);
                 builder.append('|').append(type);
                 tagString(this.tags, builder);
+
+                builder.append('\n');
             }
         });
     }

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -62,9 +62,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                         }
 
                         sendBuffer.mark();
-                        if (sendBuffer.position() > 0) {
-                            sendBuffer.put((byte) '\n');
-                        }
 
                         try {
                             writeBuilderToSendBuffer(sendBuffer);

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -76,9 +76,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                         }
 
                         sendBuffer.mark();
-                        if (sendBuffer.position() > 0) {
-                            sendBuffer.put((byte) '\n');
-                        }
 
                         try {
                             writeBuilderToSendBuffer(sendBuffer);

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -64,7 +64,8 @@ public class Telemetry {
                 .append(this.value)
                 .append('|')
                 .append(type)
-                .append(tagsString);  // already has the statsd separator baked-in
+                .append(tagsString)
+                .append('\n');  // already has the statsd separator baked-in
         }
     }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1040,7 +1040,7 @@ public class NonBlockingStatsDClientTest {
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.metrics:1|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.events:0|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.service_checks:0|c")));
-            assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.bytes_sent:31|c")));
+            assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.bytes_sent:32|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.bytes_dropped:0|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.packets_sent:1|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.packets_dropped:0|c")));

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -211,31 +211,31 @@ public class TelemetryTest {
         List<String> statsdMessages = fakeProcessor.getMessagesAsStrings() ;
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.events:2|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.events:2|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.service_checks:3|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.service_checks:3|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_sent:4|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.bytes_sent:4|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_dropped:5|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.bytes_dropped:5|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_sent:6|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_sent:6|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped:7|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_dropped:7|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped_queue:8|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_dropped_queue:8|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context:9|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.aggregated_context:9|c|#test," + telemetryTags + "\n"));
     }
 
     @Test(timeout = 5000L)
@@ -254,31 +254,31 @@ public class TelemetryTest {
         List<String> statsdMessages = fakeProcessor.getMessagesAsStrings() ;
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.events:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.events:0|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.service_checks:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.service_checks:0|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_sent:28|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.bytes_sent:29|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_dropped:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.bytes_dropped:0|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_sent:1|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_sent:1|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_dropped:0|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped_queue:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.packets_dropped_queue:0|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context:0|c|#test," + telemetryTags));
+                   hasItem("datadog.dogstatsd.client.aggregated_context:0|c|#test," + telemetryTags + "\n"));
     }
 
     @Test(timeout = 5000L)
@@ -340,14 +340,14 @@ public class TelemetryTest {
 
         List<String> statsdMessages = fakeProcessor.getMessagesAsStrings() ;
 
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.events:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.service_checks:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.bytes_sent:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.bytes_dropped:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_sent:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_dropped:0|c|#test," + telemetryTags));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_dropped_queue:0|c|#test," + telemetryTags));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics:1|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.events:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.service_checks:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.bytes_sent:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.bytes_dropped:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_sent:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_dropped:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_dropped_queue:0|c|#test," + telemetryTags + "\n"));
     }
 
     @Test(timeout = 5000L)
@@ -369,7 +369,7 @@ public class TelemetryTest {
 
         assertThat(clientError.telemetry.metricsSent.get(), equalTo(1));
         assertThat(clientError.telemetry.packetsDropped.get(), equalTo(1));
-        assertThat(clientError.telemetry.bytesDropped.get(), equalTo(26));
+        assertThat(clientError.telemetry.bytesDropped.get(), equalTo(27));
     }
 
     @Test(timeout = 5000L)
@@ -389,6 +389,6 @@ public class TelemetryTest {
 
         assertThat(client.telemetry.metricsSent.get(), equalTo(1));
         assertThat(client.telemetry.packetsSent.get(), equalTo(1));
-        assertThat(client.telemetry.bytesSent.get(), equalTo(26));
+        assertThat(client.telemetry.bytesSent.get(), equalTo(27));
     }
 }


### PR DESCRIPTION
Messages should be '\n' terminated always, using the EOL delimiter helps us understand if a metric has been truncated at the end of a payload. The server side will allow enabling a mode to drop metrics that are not properly EOL terminated to avoid processing partial metrics. 