### PR TITLE
[telemetry] dev-mode; additional metrics for better troubleshooting

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -221,6 +221,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *     Boolean to enable client telemetry.
      * @param telemetryFlushInterval
      *     Telemetry flush interval integer, in milliseconds.
+     * @param enableDevMode
+     *     Boolean to enable client telemetry in dev-mode.
      * @param aggregationFlushInterval
      *     Aggregation flush interval integer, in milliseconds. 0 disables aggregation.
      * @param aggregationShards

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -328,6 +328,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             this.telemetry = new Telemetry.Builder()
                 .tags(telemetryTags)
                 .processor(telemetryStatsDProcessor)
+                .devMode(enableDevMode)
                 .build();
 
             statsDSender = createSender(addressLookup, handler, clientChannel, statsDProcessor.getBufferPool(),

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -94,6 +94,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public static final int SOCKET_BUFFER_BYTES = -1;
     public static final boolean DEFAULT_BLOCKING = false;
     public static final boolean DEFAULT_ENABLE_TELEMETRY = true;
+    public static final boolean DEFAULT_ENABLE_DEVMODE = false;
     public static final boolean DEFAULT_ENABLE_AGGREGATION = false;
 
     public static final String CLIENT_TAG = "client:java";
@@ -231,8 +232,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
             final StatsDClientErrorHandler errorHandler, Callable<SocketAddress> addressLookup,
             Callable<SocketAddress> telemetryAddressLookup, final int timeout, final int bufferSize,
             final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
-            final int senderWorkers, boolean blocking, final boolean enableTelemetry,
-            final int telemetryFlushInterval, final int aggregationFlushInterval, final int aggregationShards)
+            final int senderWorkers, boolean blocking, final boolean enableTelemetry, final int telemetryFlushInterval,
+            final boolean enableDevMode, final int aggregationFlushInterval, final int aggregationShards)
             throws StatsDClientException {
         if ((prefix != null) && (!prefix.isEmpty())) {
             this.prefix = prefix + ".";
@@ -295,7 +296,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             Properties properties = new Properties();
             properties.load(getClass().getClassLoader().getResourceAsStream("version.properties"));
 
-            String telemetrytags = tagString(new String[]{CLIENT_TRANSPORT_TAG + transportType,
+            String telemetryTags = tagString(new String[]{CLIENT_TRANSPORT_TAG + transportType,
                                                           CLIENT_VERSION_TAG + properties.getProperty("dogstatsd_client_version"),
                                                           CLIENT_TAG}, new StringBuilder()).toString();
 
@@ -324,7 +325,10 @@ public class NonBlockingStatsDClient implements StatsDClient {
                         poolSize, 1, false, 0, aggregationShards);
             }
 
-            this.telemetry = new Telemetry(telemetrytags, telemetryStatsDProcessor);
+            this.telemetry = new Telemetry.Builder()
+                .tags(telemetryTags)
+                .processor(telemetryStatsDProcessor)
+                .build();
 
             statsDSender = createSender(addressLookup, handler, clientChannel, statsDProcessor.getBufferPool(),
                     statsDProcessor.getOutboundQueue(), senderWorkers);
@@ -380,7 +384,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
             throw new StatsDClientException("Failed to instantiate StatsD client copy", e);
         }
 
-        telemetry = new Telemetry(client.telemetry.getTags(), statsDProcessor);
+        telemetry = new Telemetry.Builder()
+            .tags(client.telemetry.getTags())
+            .processor(statsDProcessor)
+            .devMode(client.telemetry.getDevMode())
+            .build();
 
         executor.submit(statsDProcessor);
         executor.submit(statsDSender);
@@ -998,7 +1006,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
         this(prefix, queueSize, constantTags, errorHandler, addressLookup, addressLookup, timeout,
                 bufferSize, maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers,
-                blocking, enableTelemetry, telemetryFlushInterval, 0, 0);
+                blocking, enableTelemetry, telemetryFlushInterval, DEFAULT_ENABLE_DEVMODE, 0, 0);
     }
 
     protected StatsDProcessor createProcessor(final int queueSize, final StatsDClientErrorHandler handler,
@@ -1134,15 +1142,19 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
 
-    private void sendMetric(final Message message) {
-        send(message);
-        this.telemetry.incrMetricsSent(1);
+    private boolean sendMetric(final Message message) {
+        return send(message);
     }
 
-    private void send(final Message message) {
-        if (!statsDProcessor.send(message)) {
+    private boolean send(final Message message) {
+        boolean success = statsDProcessor.send(message);
+        if (success) {
+            this.telemetry.incrMetricsSent(1, message.getType());
+        } else {
             this.telemetry.incrPacketDroppedQueue(1);
         }
+
+        return success;
     }
 
     // send double with sample rate
@@ -1185,6 +1197,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
 
         if (Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) {
+
             sendMetric(new StatsDMessage<Long>(aspect, type, value, sampleRate, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
                     builder.append(this.value);

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -27,6 +27,7 @@ public class NonBlockingStatsDClientBuilder {
     public int senderWorkers = NonBlockingStatsDClient.DEFAULT_SENDER_WORKERS;
     public boolean blocking = NonBlockingStatsDClient.DEFAULT_BLOCKING;
     public boolean enableTelemetry = NonBlockingStatsDClient.DEFAULT_ENABLE_TELEMETRY;
+    public boolean enableDevMode = NonBlockingStatsDClient.DEFAULT_ENABLE_DEVMODE;
     public boolean enableAggregation = NonBlockingStatsDClient.DEFAULT_ENABLE_AGGREGATION;
     public int telemetryFlushInterval = Telemetry.DEFAULT_FLUSH_INTERVAL;
     public int aggregationFlushInterval = StatsDAggregator.DEFAULT_FLUSH_INTERVAL;
@@ -140,6 +141,11 @@ public class NonBlockingStatsDClientBuilder {
         return this;
     }
 
+    public NonBlockingStatsDClientBuilder enableDevMode(boolean val) {
+        enableDevMode = val;
+        return this;
+    }
+
     public NonBlockingStatsDClientBuilder enableAggregation(boolean val) {
         enableAggregation = val;
         return this;
@@ -191,7 +197,7 @@ public class NonBlockingStatsDClientBuilder {
         return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,
                 lookup, telemetryLookup, timeout, socketBufferSize, packetSize,
                 entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking,
-                enableTelemetry, telemetryFlushInterval,
+                enableTelemetry, telemetryFlushInterval, enableDevMode,
                 (enableAggregation ? aggregationFlushInterval : 0), aggregationShards);
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDAggregator.java
+++ b/src/main/java/com/timgroup/statsd/StatsDAggregator.java
@@ -118,7 +118,7 @@ public class StatsDAggregator {
 
                     if (telemetry.getDevMode()) {
 
-                        switch(message.getType()) {
+                        switch (message.getType()) {
                             case GAUGE:
                                 telemetry.incrAggregatedGaugeContexts(1);
                                 break;

--- a/src/main/java/com/timgroup/statsd/StatsDAggregator.java
+++ b/src/main/java/com/timgroup/statsd/StatsDAggregator.java
@@ -115,6 +115,23 @@ public class StatsDAggregator {
                 msg.aggregate(message);
                 if (telemetry != null) {
                     telemetry.incrAggregatedContexts(1);
+
+                    if (telemetry.getDevMode()) {
+
+                        switch(message.getType()) {
+                            case GAUGE:
+                                telemetry.incrAggregatedGaugeContexts(1);
+                                break;
+                            case COUNT:
+                                telemetry.incrAggregatedCountContexts(1);
+                                break;
+                            case SET:
+                                telemetry.incrAggregatedSetContexts(1);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -331,17 +331,17 @@ public class Telemetry {
         this.packetsDroppedQueue.set(0);
         this.aggregatedContexts.set(0);
 
-        // if (devMode) {
-        this.gaugeSent.set(0);
-        this.countSent.set(0);
-        this.histogramSent.set(0);
-        this.distributionSent.set(0);
-        this.setSent.set(0);
+        if (devMode) {
+            this.gaugeSent.set(0);
+            this.countSent.set(0);
+            this.histogramSent.set(0);
+            this.distributionSent.set(0);
+            this.setSent.set(0);
 
-        this.aggregatedGaugeContexts.set(0);
-        this.aggregatedCountContexts.set(0);
-        this.aggregatedSetContexts.set(0);
-        // }
+            this.aggregatedGaugeContexts.set(0);
+            this.aggregatedCountContexts.set(0);
+            this.aggregatedSetContexts.set(0);
+        }
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -185,11 +185,14 @@ public class Telemetry {
                 case COUNT:
                     incrCountSent(value);
                     break;
+                case SET:
+                    incrSetSent(value);
+                    break;
                 case HISTOGRAM:
                     incrHistogramSent(value);
                     break;
                 case DISTRIBUTION:
-                    incrHistogramSent(value);
+                    incrDistributionSent(value);
                     break;
                 default:
                     break;
@@ -250,6 +253,18 @@ public class Telemetry {
         this.aggregatedContexts.addAndGet(value);
     }
 
+    public void incrAggregatedGaugeContexts(final int value) {
+        this.aggregatedGaugeContexts.addAndGet(value);
+    }
+
+    public void incrAggregatedCountContexts(final int value) {
+        this.aggregatedCountContexts.addAndGet(value);
+    }
+
+    public void incrAggregatedSetContexts(final int value) {
+        this.aggregatedSetContexts.addAndGet(value);
+    }
+
     /**
      * Resets all counter in the telemetry (this is useful for tests purposes).
      */
@@ -263,6 +278,18 @@ public class Telemetry {
         this.packetsDropped.set(0);
         this.packetsDroppedQueue.set(0);
         this.aggregatedContexts.set(0);
+
+        // if (devMode) {
+        this.gaugeSent.set(0);
+        this.countSent.set(0);
+        this.histogramSent.set(0);
+        this.distributionSent.set(0);
+        this.setSent.set(0);
+
+        this.aggregatedGaugeContexts.set(0);
+        this.aggregatedCountContexts.set(0);
+        this.aggregatedSetContexts.set(0);
+        // }
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -114,6 +114,7 @@ public class Telemetry {
             this.devMode = devMode;
             return this;
         }
+
         public Telemetry build() {
             return new Telemetry(this.tags, this.processor, this.devMode);
         }
@@ -159,15 +160,23 @@ public class Telemetry {
         processor.send(new TelemetryMessage(this.aggregatedContextsMetric, this.aggregatedContexts.getAndSet(0), tags));
 
         if (devMode) {
-            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.gaugeSent.getAndSet(0), getTelemetryTags(tags, Message.Type.GAUGE)));
-            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.countSent.getAndSet(0), getTelemetryTags(tags, Message.Type.COUNT)));
-            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.setSent.getAndSet(0), getTelemetryTags(tags, Message.Type.SET)));
-            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.histogramSent.getAndSet(0), getTelemetryTags(tags, Message.Type.HISTOGRAM)));
-            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.distributionSent.getAndSet(0), getTelemetryTags(tags, Message.Type.DISTRIBUTION)));
+            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.gaugeSent.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.GAUGE)));
+            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.countSent.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.COUNT)));
+            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.setSent.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.SET)));
+            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.histogramSent.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.HISTOGRAM)));
+            processor.send(new TelemetryMessage(this.metricsByTypeSentMetric, this.distributionSent.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.DISTRIBUTION)));
 
-            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedGaugeContexts.getAndSet(0), getTelemetryTags(tags, Message.Type.GAUGE)));
-            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedCountContexts.getAndSet(0), getTelemetryTags(tags, Message.Type.COUNT)));
-            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedSetContexts.getAndSet(0), getTelemetryTags(tags, Message.Type.SET)));
+            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedGaugeContexts.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.GAUGE)));
+            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedCountContexts.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.COUNT)));
+            processor.send(new TelemetryMessage(this.aggregatedContextsByTypeMetric, this.aggregatedSetContexts.getAndSet(0),
+                        getTelemetryTags(tags, Message.Type.SET)));
         }
     }
 
@@ -178,53 +187,67 @@ public class Telemetry {
 
         devModeBuilder.setLength(0);
         devModeBuilder.append(tags);
-        switch(type) {
-                case GAUGE:
-                    devModeBuilder.append(",metrics_type:gauge");
-                    break;
-                case COUNT:
-                    devModeBuilder.append(",metrics_type:count");
-                    break;
-                case SET:
-                    devModeBuilder.append(",metrics_type:set");
-                    break;
-                case HISTOGRAM:
-                    devModeBuilder.append(",metrics_type:histogram");
-                    break;
-                case DISTRIBUTION:
-                    devModeBuilder.append(",metrics_type:distribution");
-                    break;
-                default:
-                    break;
+        switch (type) {
+            case GAUGE:
+                devModeBuilder.append(",metrics_type:gauge");
+                break;
+            case COUNT:
+                devModeBuilder.append(",metrics_type:count");
+                break;
+            case SET:
+                devModeBuilder.append(",metrics_type:set");
+                break;
+            case HISTOGRAM:
+                devModeBuilder.append(",metrics_type:histogram");
+                break;
+            case DISTRIBUTION:
+                devModeBuilder.append(",metrics_type:distribution");
+                break;
+            default:
+                break;
         }
 
         return devModeBuilder.toString();
     }
 
+    /**
+     * Increase Metrics Sent telemetry metric.
+     *
+     * @param value
+     *     Value to increase metric with
+     */
     public void incrMetricsSent(final int value) {
         this.metricsSent.addAndGet(value);
     }
 
+    /**
+     * Increase Metrics Sent telemetry metric, and specific metric type counter.
+     *
+     * @param value
+     *     Value to increase metric with
+     * @param type
+     *    Message type
+     */
     public void incrMetricsSent(final int value, Message.Type type) {
         incrMetricsSent(value);
-        switch(type) {
-                case GAUGE:
-                    incrGaugeSent(value);
-                    break;
-                case COUNT:
-                    incrCountSent(value);
-                    break;
-                case SET:
-                    incrSetSent(value);
-                    break;
-                case HISTOGRAM:
-                    incrHistogramSent(value);
-                    break;
-                case DISTRIBUTION:
-                    incrDistributionSent(value);
-                    break;
-                default:
-                    break;
+        switch (type) {
+            case GAUGE:
+                incrGaugeSent(value);
+                break;
+            case COUNT:
+                incrCountSent(value);
+                break;
+            case SET:
+                incrSetSent(value);
+                break;
+            case HISTOGRAM:
+                incrHistogramSent(value);
+                break;
+            case DISTRIBUTION:
+                incrDistributionSent(value);
+                break;
+            default:
+                break;
         }
     }
 

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -40,10 +40,6 @@ public class Telemetry {
     protected final String aggregatedContextsMetric = "datadog.dogstatsd.client.aggregated_context";
     protected final String aggregatedContextsByTypeMetric = "datadog.dogstatsd.client.aggregated_context_by_type";
 
-    protected final String aggregatedGaugeContextsMetric = "datadog.dogstatsd.client.aggregated_context_gauge";
-    protected final String aggregatedCountContextsMetric = "datadog.dogstatsd.client.aggregated_context_count";
-    protected final String aggregatedSetContextsMetric = "datadog.dogstatsd.client.aggregated_context_set";
-
     protected String tags;
     protected boolean devMode;
     protected StringBuilder devModeBuilder = new StringBuilder();

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1283,7 +1283,7 @@ public class NonBlockingStatsDClientTest {
                 final int senderWorkers, boolean blocking) throws StatsDClientException {
 
             super(prefix, queueSize, constantTags, errorHandler, addressLookup, addressLookup, timeout,bufferSize,
-                    maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers, blocking, false, 0, 0, 0);
+                    maxPacketSizeBytes, entityID, poolSize, processorWorkers, senderWorkers, blocking, false, 0, false, 0, 0);
             lock = new CountDownLatch(1);
         }
 

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -143,6 +143,14 @@ public class StatsDAggregatorTest {
     @BeforeClass
     public static void start() throws Exception {
         fakeProcessor = new FakeProcessor(NO_OP_HANDLER);
+
+        // set telemetry
+        Telemetry telemetry = new Telemetry.Builder()
+                .processor(fakeProcessor)
+                .devMode(true)
+                .build();
+        fakeProcessor.setTelemetry(telemetry);
+
         // 15s flush period should be enough for all tests to be done - flushes will be manual
         StatsDAggregator aggregator = new StatsDAggregator(fakeProcessor, StatsDAggregator.DEFAULT_SHARDS, 3000L);
         fakeProcessor.aggregator = aggregator;

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -255,37 +255,42 @@ public class TelemetryTest {
         List<String> statsdMessages = fakeProcessor.getMessagesAsStrings() ;
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metrics:6|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics:6|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metricsGauge:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics_by_type:2|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.GAUGE) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metricsCount:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics_by_type:2|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.COUNT) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metricsSet:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics_by_type:2|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.SET) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metricsHistogram:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics_by_type:2|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.HISTOGRAM) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.metricsDistribution:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.metrics_by_type:2|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.DISTRIBUTION) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.events:2|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.events:2|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.service_checks:3|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.service_checks:3|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_sent:4|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.bytes_sent:4|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.bytes_dropped:5|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.bytes_dropped:5|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_sent:6|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.packets_sent:6|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
                    hasItem("datadog.dogstatsd.client.packets_dropped:7|c|#test," + telemetryTags + "\n"));
@@ -297,13 +302,16 @@ public class TelemetryTest {
                    hasItem("datadog.dogstatsd.client.aggregated_context:9|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_gauge:10|c|#test," + telemetryTags + "\n"));
+                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:10|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.GAUGE) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_count:11|c|#test," + telemetryTags + "\n"));
+                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:11|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.COUNT) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_set:12|c|#test," + telemetryTags + "\n"));
+                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:12|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.SET) + "\n"));
     }
 
     @Test(timeout = 5000L)
@@ -481,6 +489,7 @@ public class TelemetryTest {
         assertThat(devModeClient.telemetry.metricsSent.get(), equalTo(4));
         assertThat(devModeClient.telemetry.gaugeSent.get(), equalTo(1));
         assertThat(devModeClient.telemetry.countSent.get(), equalTo(1));
+        assertThat(devModeClient.telemetry.setSent.get(), equalTo(0));
         assertThat(devModeClient.telemetry.histogramSent.get(), equalTo(1));
         assertThat(devModeClient.telemetry.distributionSent.get(), equalTo(1));
         assertThat(devModeClient.telemetry.packetsSent.get(), equalTo(1));
@@ -501,10 +510,16 @@ public class TelemetryTest {
         List<String> statsdMessages = fakeProcessor.getMessagesAsStrings();
 
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics:4|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metricsGauge:1|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metricsCount:1|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metricsHistogram:1|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metricsDistribution:1|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics_by_type:1|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.GAUGE) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics_by_type:1|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.COUNT) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics_by_type:0|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.SET) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics_by_type:1|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.HISTOGRAM) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.metrics_by_type:1|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.DISTRIBUTION) + "\n"));
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.events:0|c|#test," + telemetryTags + "\n"));
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.service_checks:0|c|#test," + telemetryTags + "\n"));
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.bytes_sent:106|c|#test," + telemetryTags + "\n"));
@@ -514,8 +529,11 @@ public class TelemetryTest {
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.packets_dropped_queue:0|c|#test," + telemetryTags + "\n"));
         // aggregation is disabled
         assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context:0|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_gauge:0|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_count:0|c|#test," + telemetryTags + "\n"));
-        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_set:0|c|#test," + telemetryTags + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_by_type:0|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.GAUGE) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_by_type:0|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.COUNT) + "\n"));
+        assertThat(statsdMessages, hasItem("datadog.dogstatsd.client.aggregated_context_by_type:0|c|#test," +
+                    devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.SET) + "\n"));
     }
 }

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -188,7 +188,7 @@ public class TelemetryTest {
     }
 
     @Test(timeout = 5000L)
-     public void telemetry_incrManuallyIncrData() throws Exception {
+    public void telemetry_incrManuallyIncrData() throws Exception {
 
         devModeClient.telemetry.incrMetricsSent(1);
         devModeClient.telemetry.incrGaugeSent(1);
@@ -293,24 +293,24 @@ public class TelemetryTest {
                 hasItem("datadog.dogstatsd.client.packets_sent:6|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped:7|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.packets_dropped:7|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.packets_dropped_queue:8|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.packets_dropped_queue:8|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context:9|c|#test," + telemetryTags + "\n"));
+                hasItem("datadog.dogstatsd.client.aggregated_context:9|c|#test," + telemetryTags + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:10|c|#test," +
+                hasItem("datadog.dogstatsd.client.aggregated_context_by_type:10|c|#test," +
                     devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.GAUGE) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:11|c|#test," +
+                hasItem("datadog.dogstatsd.client.aggregated_context_by_type:11|c|#test," +
                     devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.COUNT) + "\n"));
 
         assertThat(statsdMessages,
-                   hasItem("datadog.dogstatsd.client.aggregated_context_by_type:12|c|#test," +
+                hasItem("datadog.dogstatsd.client.aggregated_context_by_type:12|c|#test," +
                     devModeClient.telemetry.getTelemetryTags(telemetryTags, Message.Type.SET) + "\n"));
     }
 


### PR DESCRIPTION
This PR adds a dev-mode to the client telemetry that should better help debug metric submission, and more importantly metric aggregation. This is an initial catalog of dev-mode telemetry metrics, but more may be added in the future. 