### PR TITLE
Remove beta comment from recordDistributionValue

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1553,8 +1553,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
      *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
-     *
      * @param aspect
      *     the name of the distribution
      * @param value
@@ -1579,8 +1577,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * Records a value for the specified named distribution.
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
      *
      * @param aspect
      *     the name of the distribution

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -512,8 +512,6 @@ public interface StatsDClient extends Closeable {
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
      *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
-     *
      * @param aspect
      *     the name of the distribution
      * @param value
@@ -529,8 +527,6 @@ public interface StatsDClient extends Closeable {
      * <p>This method is a DataDog extension, and may not work with other servers.</p>
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
      *
      * @param aspect
      *     the name of the distribution
@@ -550,8 +546,6 @@ public interface StatsDClient extends Closeable {
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
      *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
-     *
      * @param aspect
      *     the name of the distribution
      * @param value
@@ -567,8 +561,6 @@ public interface StatsDClient extends Closeable {
      * <p>This method is a DataDog extension, and may not work with other servers.</p>
      *
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * <p>This is a beta feature and must be enabled specifically for your organization.</p>
      *
      * @param aspect
      *     the name of the distribution


### PR DESCRIPTION
From what I can tell the distribution metrics feature is no longer in beta and therefore this comment does not apply. If that is not the case please let me know. Thanks!

For context here is the [original PR](https://github.com/DataDog/java-dogstatsd-client/commit/438829071e550062db76ecafcb6ec7b5836f323d) that added these comments in.