### PR TITLE
[build] Remove CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,7 @@ commands:
 default_steps: &default_steps
   steps:
     - checkout
-    - create_custom_cache_lock:
-        filename: java-version-lock.txt
 
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-          - -v6-dependencies-{{ checksum "pom.xml" }}-{{ checksum "java-version-lock.txt" }}-{{ arch }}
-          # fallback to using the latest cache if no exact match is found
-          - -v6-dependencies-
-
-    - run: mvn dependency:go-offline
-
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: -v6-dependencies-{{ checksum "pom.xml" }}-{{ checksum "java-version-lock.txt" }}-{{ arch }}
     - run: |
         mvn clean install -Dgpg.skip $MVN_EXTRA_OPTS
 


### PR DESCRIPTION
Permission issue break caching in CircleCI. Given that these caches
are set up exactly as documentation expects and are valid for only 15
days, they seem to be too much trouble than what they are worth. This
commit removes the cache for now until we find a better way to handle
this problem.