### PR TITLE
[deps] Downgrade jnr-unixsocket dependency to 0.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.3</version>
+      <version>0.36</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Current version of this library (v0.38+) does not work on Java 7 so this
PR bumps up the version to the highest one that supports this
compatibility matrix.

https://app.circleci.com/pipelines/github/DataDog/java-dogstatsd-client/290/workflows/6f860b8f-e89f-4c92-bf2b-fd78db48a863
```
...
Tests run: 136, Failures: 0, Errors: 0, Skipped: 40
```