### PR TITLE
[release] Preparing README and CHANGELOG for 2.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## 2.11.0 / 2020.12.22 
+## 2.12.0 / 2020.04.05
+
+* [IMPROVEMENT] Deployments to Sonatype are now automated (but manually triggered).
+  No user-facing changes are part of this release.
+
+## 2.11.0 / 2020.12.22
 
 * [FEATURE] Aggregation: simple type client-side aggregation. See [#121][]
 * [IMPROVEMENT] UDP+UDS: set better defaults for max packet size. See [#125][]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client jar is distributed via Maven central, and can be downloaded [from Mav
 <dependency>
     <groupId>com.datadoghq</groupId>
     <artifactId>java-dogstatsd-client</artifactId>
-    <version>2.10.3</version>
+    <version>2.12.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This release has no user-facing changes but it is required for us
to test end-to-end publishing automation to Sonatype.

Note: `pom.xml` already has version `2.12.0` set from the removal of `-SNAPSHOT` suffix.