### PR TITLE
Cleanup internal threading

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -366,35 +366,22 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
-     * specified host and port.
-     * This is a shallow copy constructor meant to be used internally only.
+     * host and port specified by the given builder.
+     * The builder must be resolved before calling this internal constructor.
      *
-     * @param client
-     *    source object to copy
+     * @param builder
+     *     the resolved configuration builder
+     *
+     * @see NonBlockingStatsDClientBuilder#resolve()
      */
-    private NonBlockingStatsDClient(NonBlockingStatsDClient client)
-            throws StatsDClientException {
-
-        prefix = client.prefix;
-        handler = client.handler;
-        constantTagsRendered = client.constantTagsRendered;
-        clientChannel = client.clientChannel;
-        try {
-            statsDProcessor = createProcessor(client.statsDProcessor);
-            statsDSender = new StatsDSender(
-                    client.statsDSender, statsDProcessor.getBufferPool(), statsDProcessor.getOutboundQueue());
-        } catch (Exception e) {
-            throw new StatsDClientException("Failed to instantiate StatsD client copy", e);
-        }
-
-        telemetry = new Telemetry.Builder()
-            .tags(client.telemetry.getTags())
-            .processor(statsDProcessor)
-            .devMode(client.telemetry.getDevMode())
-            .build();
-
-        executor.submit(statsDProcessor);
-        executor.submit(statsDSender);
+    NonBlockingStatsDClient(final NonBlockingStatsDClientBuilder builder) throws StatsDClientException {
+        this(builder.prefix, builder.queueSize, builder.constantTags, builder.errorHandler,
+            builder.addressLookup, builder.telemetryAddressLookup, builder.timeout,
+            builder.socketBufferSize, builder.maxPacketSizeBytes, builder.entityID,
+            builder.bufferPoolSize, builder.processorWorkers, builder.senderWorkers,
+            builder.blocking, builder.enableTelemetry, builder.telemetryFlushInterval,
+            builder.enableDevMode, (builder.enableAggregation ? builder.aggregationFlushInterval : 0),
+            builder.aggregationShards);
     }
 
 
@@ -419,7 +406,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public NonBlockingStatsDClient(final String prefix) throws StatsDClientException {
         this(new NonBlockingStatsDClientBuilder()
             .prefix(prefix)
-            .build());
+            .resolve());
     }
 
     /**
@@ -450,7 +437,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .prefix(prefix)
             .hostname(hostname)
             .port(port)
-            .build());
+            .resolve());
     }
 
     /**
@@ -486,7 +473,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .hostname(hostname)
             .port(port)
             .queueSize(queueSize)
-            .build());
+            .resolve());
     }
 
     /**
@@ -521,7 +508,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .hostname(hostname)
             .port(port)
             .constantTags(constantTags)
-            .build());
+            .resolve());
     }
 
     /**
@@ -559,7 +546,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .port(port)
             .constantTags(constantTags)
             .maxPacketSizeBytes(maxPacketSizeBytes)
-            .build());
+            .resolve());
     }
 
     /**
@@ -597,7 +584,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .port(port)
             .queueSize(queueSize)
             .constantTags(constantTags)
-            .build());
+            .resolve());
     }
 
     /**
@@ -637,7 +624,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .port(port)
             .constantTags(constantTags)
             .errorHandler(errorHandler)
-            .build());
+            .resolve());
     }
 
     /**
@@ -679,7 +666,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .queueSize(queueSize)
             .constantTags(constantTags)
             .errorHandler(errorHandler)
-            .build());
+            .resolve());
     }
 
 
@@ -728,7 +715,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .constantTags(constantTags)
             .errorHandler(errorHandler)
             .entityID(entityID)
-            .build());
+            .resolve());
     }
 
 
@@ -775,7 +762,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .constantTags(constantTags)
             .errorHandler(errorHandler)
             .maxPacketSizeBytes(maxPacketSizeBytes)
-            .build());
+            .resolve());
     }
 
     /**
@@ -824,7 +811,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .socketBufferSize(bufferSize)
             .constantTags(constantTags)
             .errorHandler(errorHandler)
-            .build());
+            .resolve());
     }
 
     /**
@@ -861,7 +848,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .constantTags(constantTags)
             .errorHandler(errorHandler)
             .addressLookup(addressLookup)
-            .build());
+            .resolve());
     }
 
     /**
@@ -904,7 +891,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .addressLookup(addressLookup)
             .timeout(timeout)
             .socketBufferSize(bufferSize)
-            .build());
+            .resolve());
     }
 
     /**
@@ -951,7 +938,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             .timeout(timeout)
             .socketBufferSize(bufferSize)
             .maxPacketSizeBytes(maxPacketSizeBytes)
-            .build());
+            .resolve());
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -361,13 +361,13 @@ public class NonBlockingStatsDClient implements StatsDClient {
             throw new StatsDClientException("Failed to start StatsD client", e);
         }
 
-        statsDProcessor.startWorkers();
-        statsDSender.startWorkers();
+        statsDProcessor.startWorkers("StatsD-Processor-");
+        statsDSender.startWorkers("StatsD-Sender-");
 
         if (enableTelemetry) {
             if (telemetryStatsDProcessor != statsDProcessor) {
-                telemetryStatsDProcessor.startWorkers();
-                telemetryStatsDSender.startWorkers();
+                telemetryStatsDProcessor.startWorkers("StatsD-TelemetryProcessor-");
+                telemetryStatsDSender.startWorkers("StatsD-TelemetrySender-");
             }
             this.telemetry.start(telemetryFlushInterval);
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1011,15 +1011,6 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
     }
 
-    protected StatsDProcessor createProcessor(StatsDProcessor processor) throws Exception {
-
-        if (processor instanceof StatsDNonBlockingProcessor) {
-            return new StatsDNonBlockingProcessor((StatsDNonBlockingProcessor) processor);
-        }
-
-        return new StatsDBlockingProcessor((StatsDBlockingProcessor) processor);
-    }
-
     protected StatsDSender createSender(final Callable<SocketAddress> addressLookup, final StatsDClientErrorHandler handler,
             final DatagramChannel clientChannel, BufferPool pool, BlockingQueue<ByteBuffer> buffers, final int senderWorkers)
             throws Exception {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -8,7 +8,7 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.Callable;
 
-public class NonBlockingStatsDClientBuilder {
+public class NonBlockingStatsDClientBuilder implements Cloneable {
 
     /**
      * 1400 chosen as default here so that the number of bytes in a message plus the number of bytes required
@@ -171,6 +171,21 @@ public class NonBlockingStatsDClientBuilder {
      * @return the built NonBlockingStatsDClient.
      */
     public NonBlockingStatsDClient build() throws StatsDClientException {
+        return new NonBlockingStatsDClient(resolve());
+    }
+
+    /**
+     * Creates a copy of this builder with any implicit elements resolved.
+     * @return the resolved copy of the builder.
+     */
+    NonBlockingStatsDClientBuilder resolve() {
+        NonBlockingStatsDClientBuilder resolved;
+
+        try {
+            resolved = (NonBlockingStatsDClientBuilder) clone();
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException("clone");
+        }
 
         int packetSize = maxPacketSizeBytes;
         Callable<SocketAddress> lookup = addressLookup;
@@ -194,11 +209,11 @@ public class NonBlockingStatsDClientBuilder {
             }
         }
 
-        return new NonBlockingStatsDClient(prefix, queueSize, constantTags, errorHandler,
-                lookup, telemetryLookup, timeout, socketBufferSize, packetSize,
-                entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking,
-                enableTelemetry, telemetryFlushInterval, enableDevMode,
-                (enableAggregation ? aggregationFlushInterval : 0), aggregationShards);
+        resolved.maxPacketSizeBytes = packetSize;
+        resolved.addressLookup = lookup;
+        resolved.telemetryAddressLookup = telemetryLookup;
+
+        return resolved;
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -7,6 +7,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadFactory;
 
 public class NonBlockingStatsDClientBuilder implements Cloneable {
 
@@ -43,6 +44,7 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
     public String[] constantTags;
 
     public StatsDClientErrorHandler errorHandler;
+    public ThreadFactory threadFactory;
 
     public NonBlockingStatsDClientBuilder() { }
 
@@ -163,6 +165,11 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
 
     public NonBlockingStatsDClientBuilder aggregationShards(int val) {
         aggregationShards = val;
+        return this;
+    }
+
+    public NonBlockingStatsDClientBuilder threadFactory(ThreadFactory val) {
+        threadFactory = val;
         return this;
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -6,6 +6,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 
@@ -91,9 +92,11 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
 
     StatsDBlockingProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int poolSize, final int workers,
-            final int aggregatorFlushInterval, final int aggregatorShards) throws Exception {
+            final int aggregatorFlushInterval, final int aggregatorShards,
+            final ThreadFactory threadFactory) throws Exception {
 
-        super(queueSize, handler, maxPacketSizeBytes, poolSize, workers, aggregatorFlushInterval, aggregatorShards);
+        super(queueSize, handler, maxPacketSizeBytes, poolSize, workers,
+                aggregatorFlushInterval, aggregatorShards, threadFactory);
         this.messages = new ArrayBlockingQueue<>(queueSize);
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -107,13 +107,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
         return new ProcessingTask();
     }
 
-    StatsDBlockingProcessor(final StatsDBlockingProcessor processor)
-            throws Exception {
-
-        super(processor);
-        this.messages = new ArrayBlockingQueue<>(processor.getQcapacity());
-    }
-
     @Override
     protected boolean send(final Message message) {
         try {

--- a/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDBlockingProcessor.java
@@ -16,7 +16,7 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
     private class ProcessingTask extends StatsDProcessor.ProcessingTask {
 
         @Override
-        public void run() {
+        protected void processLoop() {
             ByteBuffer sendBuffer;
             boolean empty = true;
             boolean emptyHighPrio = true;
@@ -27,8 +27,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                 handler.handle(e);
                 return;
             }
-
-            aggregator.start();
 
             while (!((emptyHighPrio = highPrioMessages.isEmpty()) && (empty = messages.isEmpty()) && shutdown)) {
 
@@ -78,8 +76,7 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
                     }
                 } catch (final InterruptedException e) {
                     if (shutdown) {
-                        endSignal.countDown();
-                        return;
+                        break;
                     }
                 } catch (final Exception e) {
                     handler.handle(e);
@@ -88,8 +85,6 @@ public class StatsDBlockingProcessor extends StatsDProcessor {
 
             builder.setLength(0);
             builder.trimToSize();
-            aggregator.stop();
-            endSignal.countDown();
         }
 
     }

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -6,6 +6,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -104,10 +105,11 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
     StatsDNonBlockingProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int poolSize, final int workers,
-            final int aggregatorFlushInterval, final int aggregatorShards)
-            throws Exception {
+            final int aggregatorFlushInterval, final int aggregatorShards,
+            final ThreadFactory threadFactory) throws Exception {
 
-        super(queueSize, handler, maxPacketSizeBytes, poolSize, workers, aggregatorFlushInterval, aggregatorShards);
+        super(queueSize, handler, maxPacketSizeBytes, poolSize, workers,
+                aggregatorFlushInterval, aggregatorShards, threadFactory);
         this.qsize = new AtomicInteger(0);
         this.messages = new ConcurrentLinkedQueue<>();
     }

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -17,7 +17,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     private class ProcessingTask extends StatsDProcessor.ProcessingTask {
 
         @Override
-        public void run() {
+        protected void processLoop() {
             ByteBuffer sendBuffer;
             boolean empty = true;
             boolean emptyHighPrio = true;
@@ -28,8 +28,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                 handler.handle(e);
                 return;
             }
-
-            aggregator.start();
 
             while (!((emptyHighPrio = highPrioMessages.isEmpty()) && (empty = messages.isEmpty()) && shutdown)) {
 
@@ -92,8 +90,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                     }
                 } catch (final InterruptedException e) {
                     if (shutdown) {
-                        endSignal.countDown();
-                        return;
+                        break;
                     }
                 } catch (final Exception e) {
                     handler.handle(e);
@@ -102,8 +99,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
             builder.setLength(0);
             builder.trimToSize();
-            aggregator.stop();
-            endSignal.countDown();
         }
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -122,12 +122,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
         return new ProcessingTask();
     }
 
-    StatsDNonBlockingProcessor(final StatsDNonBlockingProcessor processor) throws Exception {
-        super(processor);
-        this.qsize = new AtomicInteger(0);
-        this.messages = new ConcurrentLinkedQueue<>();
-    }
-
     @Override
     protected boolean send(final Message message) {
         if (!shutdown) {

--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -94,32 +94,6 @@ public abstract class StatsDProcessor implements Runnable {
         this.aggregator = new StatsDAggregator(this, aggregatorShards, aggregatorFlushInterval);
     }
 
-    StatsDProcessor(final StatsDProcessor processor)
-            throws Exception {
-
-        this.handler = processor.handler;
-        this.workers = processor.workers;
-        this.qcapacity = processor.getQcapacity();
-
-        this.executor = Executors.newFixedThreadPool(workers, new ThreadFactory() {
-            final ThreadFactory delegate = Executors.defaultThreadFactory();
-            @Override
-            public Thread newThread(final Runnable runnable) {
-                final Thread result = delegate.newThread(runnable);
-                result.setName("StatsD-Processor-" + result.getName());
-                result.setDaemon(true);
-                return result;
-            }
-        });
-
-        this.bufferPool = new BufferPool(processor.bufferPool);
-        this.highPrioMessages = new ConcurrentLinkedQueue<>();
-        this.outboundQueue = new ArrayBlockingQueue<ByteBuffer>(this.bufferPool.getSize());
-        this.endSignal = new CountDownLatch(this.workers);
-        this.aggregator = new StatsDAggregator(this, processor.getAggregator().getShardGranularity(),
-                processor.getAggregator().getFlushInterval());
-    }
-
     protected abstract ProcessingTask createProcessingTask();
 
     protected abstract boolean send(final Message message);

--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -78,23 +78,14 @@ public abstract class StatsDProcessor {
 
     StatsDProcessor(final int queueSize, final StatsDClientErrorHandler handler,
             final int maxPacketSizeBytes, final int poolSize, final int workers,
-            final int aggregatorFlushInterval, final int aggregatorShards)
-            throws Exception {
+            final int aggregatorFlushInterval, final int aggregatorShards,
+            final ThreadFactory threadFactory) throws Exception {
 
         this.handler = handler;
         this.workers = workers;
         this.qcapacity = queueSize;
 
-        this.executor = Executors.newFixedThreadPool(workers, new ThreadFactory() {
-            final ThreadFactory delegate = Executors.defaultThreadFactory();
-            @Override
-            public Thread newThread(final Runnable runnable) {
-                final Thread result = delegate.newThread(runnable);
-                result.setName("StatsD-Processor-" + result.getName());
-                result.setDaemon(true);
-                return result;
-            }
-        });
+        this.executor = Executors.newFixedThreadPool(workers, threadFactory);
 
         this.bufferPool = new BufferPool(poolSize, maxPacketSizeBytes, true);
         this.highPrioMessages = new ConcurrentLinkedQueue<>();

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -35,7 +35,7 @@ public class StatsDSender {
 
     StatsDSender(final Callable<SocketAddress> addressLookup, final DatagramChannel clientChannel,
                  final StatsDClientErrorHandler handler, BufferPool pool, BlockingQueue<ByteBuffer> buffers,
-                 final int workers) throws Exception {
+                 final int workers, final ThreadFactory threadFactory) throws Exception {
 
         this.pool = pool;
         this.buffers = buffers;
@@ -46,15 +46,7 @@ public class StatsDSender {
         this.address = addressLookup.call();
         this.clientChannel = clientChannel;
 
-        this.executor = Executors.newFixedThreadPool(workers, new ThreadFactory() {
-            final ThreadFactory delegate = Executors.defaultThreadFactory();
-            @Override public Thread newThread(final Runnable runnable) {
-                final Thread result = delegate.newThread(runnable);
-                result.setName("StatsD-Sender-" + result.getName());
-                result.setDaemon(true);
-                return result;
-            }
-        });
+        this.executor = Executors.newFixedThreadPool(workers, threadFactory);
         this.endSignal = new CountDownLatch(workers);
     }
 

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -58,24 +58,6 @@ public class StatsDSender implements Runnable {
         this.endSignal = new CountDownLatch(workers);
     }
 
-    StatsDSender(final Callable<SocketAddress> addressLookup, final DatagramChannel clientChannel,
-                 final StatsDClientErrorHandler handler, BufferPool pool, BlockingQueue<ByteBuffer> buffers)
-            throws Exception {
-        this(addressLookup, clientChannel, handler, pool, buffers, DEFAULT_WORKERS);
-    }
-
-    StatsDSender(final StatsDSender sender) throws Exception {
-        this(sender.addressLookup, sender.clientChannel, sender.handler,
-                sender.pool, sender.buffers, sender.workers);
-        this.setTelemetry(sender.getTelemetry());
-    }
-
-    StatsDSender(final StatsDSender sender, BufferPool pool, BlockingQueue<ByteBuffer> buffers) throws Exception {
-        this(sender.addressLookup, sender.clientChannel, sender.handler,
-                pool, buffers, sender.workers);
-        this.setTelemetry(sender.getTelemetry());
-    }
-
     public void setTelemetry(final Telemetry telemetry) {
         this.telemetry = telemetry;
     }

--- a/src/main/java/com/timgroup/statsd/StatsDThreadFactory.java
+++ b/src/main/java/com/timgroup/statsd/StatsDThreadFactory.java
@@ -1,0 +1,16 @@
+package com.timgroup.statsd;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public final class StatsDThreadFactory implements ThreadFactory {
+    private final ThreadFactory delegate = Executors.defaultThreadFactory();
+
+    @Override
+    public Thread newThread(final Runnable runnable) {
+        final Thread result = delegate.newThread(runnable);
+        result.setName("StatsD-" + result.getName());
+        result.setDaemon(true);
+        return result;
+    }
+}

--- a/src/main/java/com/timgroup/statsd/StatsDThreadFactory.java
+++ b/src/main/java/com/timgroup/statsd/StatsDThreadFactory.java
@@ -3,7 +3,7 @@ package com.timgroup.statsd;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
-public final class StatsDThreadFactory implements ThreadFactory {
+final class StatsDThreadFactory implements ThreadFactory {
     private final ThreadFactory delegate = Executors.defaultThreadFactory();
 
     @Override

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -93,7 +93,7 @@ public class StatsDAggregatorTest {
 
         private class FakeProcessingTask extends StatsDProcessor.ProcessingTask {
             @Override
-            public void run() {
+            protected void processLoop() {
 
                 while (!shutdown) {
                     final Message message = messages.poll();
@@ -154,7 +154,7 @@ public class StatsDAggregatorTest {
         // 15s flush period should be enough for all tests to be done - flushes will be manual
         StatsDAggregator aggregator = new StatsDAggregator(fakeProcessor, StatsDAggregator.DEFAULT_SHARDS, 3000L);
         fakeProcessor.aggregator = aggregator;
-        executor.submit(fakeProcessor);
+        fakeProcessor.startWorkers();
     }
 
     @AfterClass
@@ -234,8 +234,6 @@ public class StatsDAggregatorTest {
 
     @Test(timeout = 5000L)
     public void aggregation_flushing() throws Exception {
-        // start clockwork
-        fakeProcessor.aggregator.start();
 
         for(int i=0 ; i<10 ; i++) {
             fakeProcessor.send(new FakeMessage<>("some.gauge", Message.Type.GAUGE, i));

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -86,7 +86,7 @@ public class StatsDAggregatorTest {
         private final AtomicInteger messageAggregated = new AtomicInteger(0);
 
         FakeProcessor(final StatsDClientErrorHandler handler) throws Exception {
-            super(0, handler, 0, 1, 1, 0, 0);
+            super(0, handler, 0, 1, 1, 0, 0, new StatsDThreadFactory());
             this.messages = new ConcurrentLinkedQueue<>();
         }
 

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -154,7 +154,7 @@ public class StatsDAggregatorTest {
         // 15s flush period should be enough for all tests to be done - flushes will be manual
         StatsDAggregator aggregator = new StatsDAggregator(fakeProcessor, StatsDAggregator.DEFAULT_SHARDS, 3000L);
         fakeProcessor.aggregator = aggregator;
-        fakeProcessor.startWorkers();
+        fakeProcessor.startWorkers("StatsD-Test-");
     }
 
     @AfterClass

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -33,7 +33,7 @@ public class TelemetryTest {
         public final List<Message> messages = new ArrayList<>();
 
         FakeProcessor(final StatsDClientErrorHandler handler) throws Exception {
-            super(0, handler, 0, 1, 1, 0, 0);
+            super(0, handler, 0, 1, 1, 0, 0, new StatsDThreadFactory());
         }
 
 

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -39,7 +39,7 @@ public class TelemetryTest {
 
         private class FakeProcessingTask extends StatsDProcessor.ProcessingTask {
             @Override
-            public void run() {}
+            protected void processLoop() {}
         }
 
         @Override
@@ -48,8 +48,7 @@ public class TelemetryTest {
             return true;
         }
 
-        @Override
-        public void run(){}
+        void startWorkers() {}
 
         @Override
         protected ProcessingTask createProcessingTask() {


### PR DESCRIPTION
These changes cleanup and simplify the internal threading model so that the Java tracer can upgrade to the latest level of `java-dogstatsd-client`. It also adds support for using a custom thread factory which allows the Java tracer to configure StatsD threads so they are marked as agent related threads.

List of the changes:

* Avoid creating intermediate `NonBlockingStatsDClients` via copy-constructors
  because each call to `NonBlockingStatsDClient` will end up spawning threads - instead we:
  * copy the current builder (to avoid side-effects)
  * resolve implicit elements
  * use the resolved builder to create the `NonBlockingStatsDClient` once

* Remove unused copy-constructors

* Remove intermediate thread pool, clean-up shutdown logic

* Support using a custom thread factory to spawn StatsD worker threads

* Replace fixed-size thread pools with a much simpler arrays of threads
  (since each StatsD worker is a busy loop that takes up exactly one thread)

