### PR TITLE
Fix unicode length calculations in event strings

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -11,6 +11,7 @@ import java.lang.Double;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.nio.charset.Charset;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -101,6 +102,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public static final String CLIENT_VERSION_TAG = "client_version:";
     public static final String CLIENT_TRANSPORT_TAG = "client_transport:";
 
+
+    /**
+     * UTF-8 is the expected encoding for data sent to the agent.
+     */
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final StatsDClientErrorHandler NO_OP_HANDLER = new StatsDClientErrorHandler() {
         @Override public void handle(final Exception ex) { /* No-op */ }
@@ -1691,9 +1697,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 final String text = escapeEventString(event.getText());
                 builder.append(Message.Type.EVENT.toString())
                     .append("{")
-                    .append(title.length())
+                    .append(getUtf8Length(title))
                     .append(",")
-                    .append(text.length())
+                    .append(getUtf8Length(text))
                     .append("}:")
                     .append(title)
                 .append("|").append(text);
@@ -1708,6 +1714,10 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     private static String escapeEventString(final String title) {
         return title.replace("\n", "\\n");
+    }
+
+    private int getUtf8Length(final String text) {
+        return text.getBytes(UTF_8).length;
     }
 
     /**

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -783,7 +783,24 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{16,12}:my.prefix.title1|text1\\nline2|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1")));
+        assertThat(
+            server.messagesReceived(),
+            hasItem(comparesEqualTo("_e{16,12}:my.prefix.title1|text1\\nline2|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1"))
+        );
+    }
+
+    @Test(timeout = 5000L)
+    public void send_unicode_event() throws Exception {
+        final Event event = Event.builder()
+            .withTitle("Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded")
+            .withText("Delivered — destination.csv").build();
+        assertEquals(event.getText(), "Delivered — destination.csv");
+        client.recordEvent(event);
+        server.waitForMessage();
+        assertThat(
+            server.messagesReceived(),
+            hasItem(comparesEqualTo("_e{89,29}:my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded|Delivered — destination.csv"))
+        );
     }
 
     @Test(timeout = 5000L)


### PR DESCRIPTION
Old code calculated the length of header and message body sent to statsd
using codepoints instead of raw byte UTF-8 lengths. The new code now ensures
that both of those field lengths are properly calculated using the
expected encoding.

Fixes: #148