### PR TITLE
Add recordGaugeDelta in StatsDClient.

### DIFF
--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -44,6 +44,10 @@ public final class NoOpStatsDClient implements StatsDClient {
 
     @Override public void recordGaugeValue(String aspect, long value, double sampleRate, String... tags) { }
 
+    @Override public void recordGaugeDelta(String aspect, long delta, String... tags) { }
+
+    @Override public void recordGaugeDelta(String aspect, double delta, String... tags) { }
+
     @Override public void gauge(String aspect, double value, String... tags) { }
 
     @Override public void gauge(String aspect, double value, double sampleRate, String... tags) { }

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -274,6 +274,25 @@ public interface StatsDClient extends Closeable {
     void recordGaugeValue(String aspect, long value, double sampleRate, String... tags);
 
     /**
+     * Records a change in the value of the specified named gauge.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the gauge
+     * @param delta
+     *     the +/- delta to apply to the gauge
+     */
+    void recordGaugeDelta(String aspect, long delta, String... tags);
+
+    /**
+     * Convenience method equivalent to {@link #recordGaugeDelta(String, long, String[])} but for double deltas.
+     */
+    void recordGaugeDelta(String aspect, double delta, String... tags);
+
+    /**
      * Convenience method equivalent to {@link #recordGaugeValue(String, double, String[])}.
      *
      * @param aspect

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -257,6 +257,46 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_positive_gauge_delta_to_statsd_with_tags() throws Exception {
+
+
+        client.recordGaugeDelta("mygauge", 423, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:+423|g|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_negative_gauge_delta_to_statsd_with_tags() throws Exception {
+
+
+        client.recordGaugeDelta("mygauge", -123, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:-123|g|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_double_gauge_delta_to_statsd_with_tags() throws Exception {
+
+
+        client.recordGaugeDelta("mygauge", 0.423, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:+0.423|g|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_negative_double_gauge_delta_to_statsd_with_tags() throws Exception {
+
+
+        client.recordGaugeDelta("mygauge", -0.123, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:-0.123|g|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_histogram_to_statsd() throws Exception {
 
         client.recordHistogramValue("myhistogram", 423);


### PR DESCRIPTION
Resolves issue: https://github.com/DataDog/java-dogstatsd-client/issues/36

Interface name `recordGaugeDelta` is made similar from: https://github.com/tim-group/java-statsd-client/blob/ec75702a61af3daabd9c826f687243a3ee6fcde9/src/main/java/com/timgroup/statsd/StatsDClient.java#L111

StatsD gauge delta specification can be found here: https://github.com/statsd/statsd/blob/master/docs/metric_types.md#gauges
 