### PR TITLE
Set client side aggregation flush interval to 2s

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDAggregator.java
+++ b/src/main/java/com/timgroup/statsd/StatsDAggregator.java
@@ -15,7 +15,7 @@ import java.util.TimerTask;
 
 
 public class StatsDAggregator {
-    public static int DEFAULT_FLUSH_INTERVAL = 3000; // 3s
+    public static int DEFAULT_FLUSH_INTERVAL = 2000; // 2s
     public static int DEFAULT_SHARDS = 4;  // 4 partitions to reduce contention.
 
     protected final String AGGREGATOR_THREAD_NAME = "statsd-aggregator-thread";


### PR DESCRIPTION
Update client side flush interval from 3s to 2s.

Motivation: see DataDog/datadog-go#199.