### PR TITLE
Fix High sev vulnerability in underlying library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
-            <version>0.36</version>
+            <version>0.38.9</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes exposure to [use-after-free vulnerability](https://github.com/jnr/jnr-posix/issues/170) in jnr-posix, through jnr-unixsocket