### PR TITLE
[client] enable aggregation by default

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -90,7 +90,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public static final boolean DEFAULT_BLOCKING = false;
     public static final boolean DEFAULT_ENABLE_TELEMETRY = true;
     public static final boolean DEFAULT_ENABLE_DEVMODE = false;
-    public static final boolean DEFAULT_ENABLE_AGGREGATION = false;
+    public static final boolean DEFAULT_ENABLE_AGGREGATION = true;
 
     public static final String CLIENT_TAG = "client:java";
     public static final String CLIENT_VERSION_TAG = "client_version:";

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -110,13 +110,13 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * The NumberFormat instances are not threadsafe and thus defined as ThreadLocal
      * for safety.
      */
-    private static final ThreadLocal<NumberFormat> NUMBER_FORMATTER = new ThreadLocal<NumberFormat>() {
+    protected static final ThreadLocal<NumberFormat> NUMBER_FORMATTER = new ThreadLocal<NumberFormat>() {
         @Override
         protected NumberFormat initialValue() {
             return newFormatter(false);
         }
     };
-    private static final ThreadLocal<NumberFormat> SAMPLE_RATE_FORMATTER = new ThreadLocal<NumberFormat>() {
+    protected static final ThreadLocal<NumberFormat> SAMPLE_RATE_FORMATTER = new ThreadLocal<NumberFormat>() {
         @Override
         protected NumberFormat initialValue() {
             return newFormatter(true);
@@ -149,7 +149,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         return numberFormatter;
     }
 
-    private static String format(ThreadLocal<NumberFormat> formatter, Number value) {
+    protected static String format(ThreadLocal<NumberFormat> formatter, Number value) {
         return formatter.get().format(value);
     }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientMaxPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientMaxPerfTest.java
@@ -107,6 +107,7 @@ public final class NonBlockingStatsDClientMaxPerfTest {
             .queueSize(qSize)
             .senderWorkers(senderWorkers)
             .processorWorkers(processorWorkers)
+            .enableAggregation(false)
             .build();
         this.server = new DummyLowMemStatsDServer(port);
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.Random;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,7 +24,15 @@ public final class NonBlockingStatsDClientPerfTest {
         .hostname("localhost")
         .port(STATSD_SERVER_PORT)
         .blocking(true)  // non-blocking processors will drop messages if the queue fills up
+        .enableAggregation(false)
         .build();
+
+    private static final NonBlockingStatsDClient clientAggr = new NonBlockingStatsDClientBuilder().prefix("my.prefix.aggregated")
+        .hostname("localhost")
+        .port(STATSD_SERVER_PORT)
+        .blocking(true)  // non-blocking processors will drop messages if the queue fills up
+        .build();
+
     private final ExecutorService executor = Executors.newFixedThreadPool(10);
     private static DummyStatsDServer server;
 
@@ -38,6 +47,11 @@ public final class NonBlockingStatsDClientPerfTest {
     public static void stop() throws Exception {
         client.stop();
         server.close();
+    }
+
+    @After
+    public void clear() throws Exception {
+        server.clear();
     }
 
     @Test(timeout=30000)
@@ -69,5 +83,43 @@ public final class NonBlockingStatsDClientPerfTest {
         log.info("Packets at server: " + server.packetsReceived());
 
         assertEquals(testSize, server.messagesReceived().size());
+    }
+
+    @Test(timeout=30000)
+    public void perfAggregatedTest() throws Exception {
+
+        int expectedSize = 2;
+        long start = System.currentTimeMillis();
+        boolean done = false;
+
+        while(!done) {
+            executor.submit(new Runnable() {
+                public void run() {
+                    clientAggr.count("mycount", 1);
+                }
+            });
+
+            long elapsed = System.currentTimeMillis() - start;
+            if  (elapsed > clientAggr.statsDProcessor.getAggregator().getFlushInterval()) {
+                done = true;
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(20, TimeUnit.SECONDS);
+
+        int messages;
+        while((messages = server.messagesReceived().size()) < expectedSize) {
+
+            log.info("Messages at server: " + messages);
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {}
+        }
+
+        log.info("Messages at server: " + messages);
+        log.info("Packets at server: " + server.packetsReceived());
+
+        assertEquals(expectedSize, server.messagesReceived().size());
     }
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -88,7 +88,7 @@ public final class NonBlockingStatsDClientPerfTest {
     @Test(timeout=30000)
     public void perfAggregatedTest() throws Exception {
 
-        int expectedSize = 2;
+        int expectedSize = 2 + 21;
         long start = System.currentTimeMillis();
         boolean done = false;
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -29,12 +29,8 @@ import static org.junit.Assert.assertTrue;
 public class NonBlockingStatsDClientTest {
 
     private static final int STATSD_SERVER_PORT = 17254;
-    private static final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-        .prefix("my.prefix")
-        .hostname("localhost")
-        .port(STATSD_SERVER_PORT)
-        .enableTelemetry(false)
-        .build();
+    private static NonBlockingStatsDClient client;
+    private static NonBlockingStatsDClient clientUnaggregated;
     private static DummyStatsDServer server;
 
     private static Logger log = Logger.getLogger("NonBlockingStatsDClientTest");
@@ -45,12 +41,26 @@ public class NonBlockingStatsDClientTest {
     @BeforeClass
     public static void start() throws IOException {
         server = new DummyStatsDServer(STATSD_SERVER_PORT);
+        client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(STATSD_SERVER_PORT)
+            .enableTelemetry(false)
+            .build();
+        clientUnaggregated = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(STATSD_SERVER_PORT)
+            .enableTelemetry(false)
+            .enableAggregation(false)
+            .build();
     }
 
     @AfterClass
     public static void stop() {
         try {
             client.stop();
+            clientUnaggregated.stop();
             server.close();
         } catch (java.io.IOException ignored) {
         }
@@ -78,7 +88,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_counter_value_with_sample_rate_to_statsd() throws Exception {
 
-        client.count("mycount", 24, 1);
+        clientUnaggregated.count("mycount", 24, 1);
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|@1.000000")));
@@ -114,7 +124,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_counter_value_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-        client.count("mycount", 24, 1, "foo:bar", "baz");
+        clientUnaggregated.count("mycount", 24, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|@1.000000|#baz,foo:bar")));
@@ -142,7 +152,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_counter_increment_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-        client.incrementCounter("myinc", 1, "foo:bar", "baz");
+        clientUnaggregated.incrementCounter("myinc", 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myinc:1|c|@1.000000|#baz,foo:bar")));
@@ -169,8 +179,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_counter_decrement_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.decrementCounter("mydec", 1, "foo:bar", "baz");
+        clientUnaggregated.decrementCounter("mydec", 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydec:-1|c|@1.000000|#baz,foo:bar")));
@@ -189,8 +198,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_gauge_with_sample_rate_to_statsd() throws Exception {
 
-
-        client.recordGaugeValue("mygauge", 423, 1);
+        clientUnaggregated.recordGaugeValue("mygauge", 423, 1);
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|@1.000000")));
@@ -239,8 +247,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_gauge_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.recordGaugeValue("mygauge", 423, 1, "foo:bar", "baz");
+        clientUnaggregated.recordGaugeValue("mygauge", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|@1.000000|#baz,foo:bar")));
@@ -288,8 +295,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_histogram_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.recordHistogramValue("myhistogram", 423, 1, "foo:bar", "baz");
+        clientUnaggregated.recordHistogramValue("myhistogram", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:423|h|@1.000000|#baz,foo:bar")));
@@ -308,8 +314,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_double_histogram_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.recordHistogramValue("myhistogram", 0.423, 1, "foo:bar", "baz");
+        clientUnaggregated.recordHistogramValue("myhistogram", 0.423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:0.423|h|@1.000000|#baz,foo:bar")));
@@ -347,8 +352,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_distribution_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.recordDistributionValue("mydistribution", 423, 1, "foo:bar", "baz");
+        clientUnaggregated.recordDistributionValue("mydistribution", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423|d|@1.000000|#baz,foo:bar")));
@@ -367,8 +371,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_double_distribution_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-
-        client.recordDistributionValue("mydistribution", 0.423, 1, "foo:bar", "baz");
+        clientUnaggregated.recordDistributionValue("mydistribution", 0.423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423|d|@1.000000|#baz,foo:bar")));
@@ -423,7 +426,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_timer_with_sample_rate_to_statsd_with_tags() throws Exception {
 
-        client.recordExecutionTime("mytime", 123, 1, "foo:bar", "baz");
+        clientUnaggregated.recordExecutionTime("mytime", 123, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mytime:123|ms|@1.000000|#baz,foo:bar")));
@@ -487,6 +490,7 @@ public class NonBlockingStatsDClientTest {
             .port(STATSD_SERVER_PORT)
             .queueSize(Integer.MAX_VALUE)
             .constantTags("instance:foo", "app:bar")
+            .enableAggregation(false)
             .build();
         try {
             client.gauge("value", 423, 1, "baz");
@@ -659,7 +663,7 @@ public class NonBlockingStatsDClientTest {
         }
     }
 
-    @Test(timeout = 5000L)
+    @Test(timeout = 15000L)
     public void checkEnvVars() {
         final Random r = new Random();
         for (final NonBlockingStatsDClient.Literal literal : NonBlockingStatsDClient.Literal.values()) {
@@ -674,6 +678,7 @@ public class NonBlockingStatsDClientTest {
             server.clear();
             client.gauge("value", 42);
             server.waitForMessage("checkEnvVars.value");
+            log.info("passed for '" + literal + "'; env cleaned.");
             assertThat(server.messagesReceived(), hasItem(comparesEqualTo("checkEnvVars.value:42|g|#" +
                     literal.tag() + ":" + randomString)));
             assertThat(server.messagesReceived(), hasItem(comparesEqualTo("checkEnvVars.value:42|g|#" +

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -17,6 +17,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Logger;
+import java.text.NumberFormat;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
@@ -1269,6 +1270,39 @@ public class NonBlockingStatsDClientTest {
         } finally {
             testClient.stop();
         }
+    }
+
+    @Test
+    public void testMessageHashcode() throws Exception {
+
+        StatsDTestMessage previous = new StatsDTestMessage<Long>("my.count", Message.Type.COUNT, Long.valueOf(1), 0, new String[0]) {
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(this.value);
+            };
+        };
+        StatsDTestMessage previousTagged =
+            new StatsDTestMessage<Long>("my.count", Message.Type.COUNT, Long.valueOf(1), 0, new String[] {"foo", "bar"}) {
+
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(this.value);
+            };
+        };
+
+        StatsDTestMessage next = new StatsDTestMessage<Long>("my.count", Message.Type.COUNT, Long.valueOf(1), 0, new String[0]) {
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(this.value);
+            };
+        };
+        StatsDTestMessage nextTagged =
+            new StatsDTestMessage<Long>("my.count", Message.Type.COUNT, Long.valueOf(1), 0, new String[] {"foo", "bar"}) {
+
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(this.value);
+            };
+        };
+
+        assertEquals(previous.hashCode(), next.hashCode());
+        assertEquals(previousTagged.hashCode(), nextTagged.hashCode());
     }
 
     @Test(timeout = 5000L)

--- a/src/test/java/com/timgroup/statsd/StatsDTestMessage.java
+++ b/src/test/java/com/timgroup/statsd/StatsDTestMessage.java
@@ -1,0 +1,27 @@
+package com.timgroup.statsd;
+
+class StatsDTestMessage<T extends Number> extends NumericMessage<T> {
+    final double sampleRate; // NaN for none
+
+    protected StatsDTestMessage(String aspect, Message.Type type, T value, double sampleRate, String[] tags) {
+        super(aspect, type, value, tags);
+        this.sampleRate = sampleRate;
+    }
+
+    @Override
+    public final void writeTo(StringBuilder builder) {
+        builder.append("test.").append(aspect).append(':');
+        writeValue(builder);
+        builder.append('|').append(type);
+        if (!Double.isNaN(sampleRate)) {
+            builder.append('|').append('@').append(NonBlockingStatsDClient.format(NonBlockingStatsDClient.SAMPLE_RATE_FORMATTER, sampleRate));
+        }
+        NonBlockingStatsDClient.tagString(this.tags, "", builder);
+
+        builder.append('\n');
+    }
+
+    protected void writeValue(StringBuilder builder) {
+        builder.append(NonBlockingStatsDClient.format(NonBlockingStatsDClient.NUMBER_FORMATTER, this.value));
+    }
+}

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class UnixSocketTest implements StatsDClientErrorHandler {
     private static File tmpFolder;
     private static NonBlockingStatsDClient client;
+    private static NonBlockingStatsDClient clientAggregate;
     private static DummyStatsDServer server;
     private static File socketFile;
     private volatile Exception lastException = new Exception();
@@ -53,13 +54,25 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
             .queueSize(1)
             .timeout(1)  // non-zero timeout to ensure exception triggered if socket buffer full.
             .socketBufferSize(1024 * 1024)
+            .enableAggregation(false)
             .errorHandler(this)
             .build();
-        }
+
+        clientAggregate = new NonBlockingStatsDClientBuilder().prefix("my.prefix")
+            .hostname(socketFile.toString())
+            .port(0)
+            .queueSize(1)
+            .timeout(1)  // non-zero timeout to ensure exception triggered if socket buffer full.
+            .socketBufferSize(1024 * 1024)
+            .enableAggregation(false)
+            .errorHandler(this)
+            .build();
+    }
 
     @After
     public void stop() throws Exception {
         client.stop();
+        clientAggregate.stop();
         server.close();
     }
 


### PR DESCRIPTION
This change will set aggregation for simple types by default, this would reduce the overall packet traffic to the server. The goal is to reduce the overall load on the dogstatsd client-server environments. Aggregation comes with a slight overhead on the client side, but it's clearly offset by the gains on the server side.

Please note that this PR has the effect of making metric submission with sample rates ineffectual as they make no sense in the context of metric aggregation. In practice, the metric is just aggregated and the sampling is just ignored.