### PR TITLE
update jnr-unixsocket version to fix vulnerability 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
-            <version>0.36</version>
+            <version>0.38.11</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
`jnr-unixsocket 0.36` is using `jnr-posix 3.0.61` which is affected by Use After Free vulnerability. 
Updating it to latest, to fix vulnerability https://snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422
