### PR TITLE
Allow clients to override metric sampling

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1798,7 +1798,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         });
     }
 
-    private boolean isInvalidSample(double sampleRate) {
+    protected boolean isInvalidSample(double sampleRate) {
         return sampleRate != 1 && ThreadLocalRandom.current().nextDouble() > sampleRate;
     }
 


### PR DESCRIPTION
For example when submitting pre-sampled metrics to the client.