### PR TITLE
Add named pipe support for windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@2.4.1
+
 commands:
   create_custom_cache_lock:
     description: "Create custom cache lock for java version."
@@ -45,6 +48,9 @@ jobs:
     docker:
       - image: circleci/openjdk:14.0.2-buster
     <<: *default_steps
+  windows-openjdk12:
+    executor: win/default
+    <<: *default_steps
 
 workflows:
   version: 2
@@ -55,3 +61,4 @@ workflows:
       - openjdk9
       - openjdk11
       - openjdk13
+      - windows-openjdk12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,12 @@ jobs:
     <<: *default_steps
   windows-openjdk12:
     executor: win/default
-    <<: *default_steps
+    steps:
+      - checkout
+      - run: |
+          choco install maven
+      - run: |
+          mvn clean install
 
 workflows:
   version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <version>1.18.0</version>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <scope>test</scope>
+            <version>5.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
             <version>0.36</version>

--- a/src/main/java/com/timgroup/statsd/ClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/ClientChannel.java
@@ -1,8 +1,5 @@
 package com.timgroup.statsd;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 
 public interface ClientChannel extends WritableByteChannel {

--- a/src/main/java/com/timgroup/statsd/ClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/ClientChannel.java
@@ -1,0 +1,10 @@
+package com.timgroup.statsd;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+public interface ClientChannel extends WritableByteChannel {
+    String getTransportType();
+}

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -12,6 +12,7 @@ public class DatagramClientChannel implements ClientChannel {
     /**
      * Creates a new DatagramClientChannel using the default DatagramChannel.
      * @param address Address to connect the channel to
+     * @throws IOException if an I/O error occurs
      */
     public DatagramClientChannel(SocketAddress address) throws IOException {
         this(DatagramChannel.open(), address);
@@ -19,6 +20,7 @@ public class DatagramClientChannel implements ClientChannel {
 
     /**
      * Creates a new DatagramClientChannel that wraps the delegate.
+     * @param delegate Implementation this instance wraps
      * @param address Address to connect the channel to
      */
     public DatagramClientChannel(DatagramChannel delegate, SocketAddress address) {

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -10,7 +10,7 @@ public class DatagramClientChannel implements ClientChannel {
     private final SocketAddress address;
 
     /**
-     * Creates a new DatagramClientChannel using the default DatagramChannel
+     * Creates a new DatagramClientChannel using the default DatagramChannel.
      * @param address Address to connect the channel to
      */
     public DatagramClientChannel(SocketAddress address) throws IOException {

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -10,6 +10,7 @@ import java.nio.channels.DatagramChannel;
 public class DatagramClientChannel implements ClientChannel {
     private final DatagramChannel delegate;
     private final String transport;
+    private final SocketAddress address;
 
     /**
      * Creates a new DatagramClientChannel that wraps the delegate.
@@ -23,7 +24,7 @@ public class DatagramClientChannel implements ClientChannel {
         } else {
             transport = "udp";
         }
-        delegate.connect(address);
+        this.address = address;
     }
 
     @Override
@@ -33,7 +34,7 @@ public class DatagramClientChannel implements ClientChannel {
 
     @Override
     public int write(ByteBuffer src) throws IOException {
-        return delegate.write(src);
+        return delegate.send(src, address);
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -1,29 +1,28 @@
 package com.timgroup.statsd;
 
-import jnr.unixsocket.UnixDatagramChannel;
-
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 
 public class DatagramClientChannel implements ClientChannel {
-    private final DatagramChannel delegate;
-    private final String transport;
+    protected final DatagramChannel delegate;
     private final SocketAddress address;
+
+    /**
+     * Creates a new DatagramClientChannel using the default DatagramChannel
+     * @param address Address to connect the channel to
+     */
+    public DatagramClientChannel(SocketAddress address) throws IOException {
+        this(DatagramChannel.open(), address);
+    }
 
     /**
      * Creates a new DatagramClientChannel that wraps the delegate.
      * @param address Address to connect the channel to
      */
-    public DatagramClientChannel(DatagramChannel delegate, SocketAddress address) throws IOException {
+    public DatagramClientChannel(DatagramChannel delegate, SocketAddress address) {
         this.delegate = delegate;
-
-        if (delegate instanceof UnixDatagramChannel) {
-            transport = "uds";
-        } else {
-            transport = "udp";
-        }
         this.address = address;
     }
 
@@ -44,6 +43,6 @@ public class DatagramClientChannel implements ClientChannel {
 
     @Override
     public String getTransportType() {
-        return transport;
+        return "udp";
     }
 }

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -45,4 +45,9 @@ public class DatagramClientChannel implements ClientChannel {
     public String getTransportType() {
         return "udp";
     }
+
+    @Override
+    public String toString() {
+        return "[" + getTransportType() + "] " + address;
+    }
 }

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -1,0 +1,48 @@
+package com.timgroup.statsd;
+
+import jnr.unixsocket.UnixDatagramChannel;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+
+public class DatagramClientChannel implements ClientChannel {
+    private final DatagramChannel delegate;
+    private final String transport;
+
+    /**
+     * Creates a new DatagramClientChannel that wraps the delegate.
+     * @param address Address to connect the channel to
+     */
+    public DatagramClientChannel(DatagramChannel delegate, SocketAddress address) throws IOException {
+        this.delegate = delegate;
+
+        if (delegate instanceof UnixDatagramChannel) {
+            transport = "uds";
+        } else {
+            transport = "udp";
+        }
+        delegate.connect(address);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return delegate.write(src);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public String getTransportType() {
+        return transport;
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -11,6 +11,9 @@ public class NamedPipeClientChannel implements ClientChannel {
     private final FileChannel fileChannel;
     private final String pipe;
 
+    /**
+     * Creates a new NamedPipeClientChannel with the given address.
+     */
     public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
         pipe = address.getPipe();
         randomAccessFile = new RandomAccessFile(pipe, "rw");

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -1,0 +1,39 @@
+package com.timgroup.statsd;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+public class NamedPipeClientChannel implements ClientChannel {
+    private final RandomAccessFile randomAccessFile;
+    private final FileChannel fileChannel;
+
+    public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
+        randomAccessFile = new RandomAccessFile(address.getPipe(), "w");
+        fileChannel = randomAccessFile.getChannel();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return fileChannel.isOpen();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return fileChannel.write(src);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // closing the file also closes the channel
+        randomAccessFile.close();
+    }
+
+    @Override
+    public String getTransportType() {
+        return "namedpipe";
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -12,7 +12,7 @@ public class NamedPipeClientChannel implements ClientChannel {
     private final FileChannel fileChannel;
 
     public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
-        randomAccessFile = new RandomAccessFile(address.getPipe(), "w");
+        randomAccessFile = new RandomAccessFile(address.getPipe(), "rw");
         fileChannel = randomAccessFile.getChannel();
     }
 

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -13,6 +13,9 @@ public class NamedPipeClientChannel implements ClientChannel {
 
     /**
      * Creates a new NamedPipeClientChannel with the given address.
+     *
+     * @param address Location of named pipe
+     * @throws FileNotFoundException if pipe does not exist
      */
     public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
         pipe = address.getPipe();

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.WritableByteChannel;
 
 public class NamedPipeClientChannel implements ClientChannel {
     private final RandomAccessFile randomAccessFile;

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -9,9 +9,11 @@ import java.nio.channels.FileChannel;
 public class NamedPipeClientChannel implements ClientChannel {
     private final RandomAccessFile randomAccessFile;
     private final FileChannel fileChannel;
+    private final String pipe;
 
     public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
-        randomAccessFile = new RandomAccessFile(address.getPipe(), "rw");
+        pipe = address.getPipe();
+        randomAccessFile = new RandomAccessFile(pipe, "rw");
         fileChannel = randomAccessFile.getChannel();
     }
 
@@ -34,5 +36,10 @@ public class NamedPipeClientChannel implements ClientChannel {
     @Override
     public String getTransportType() {
         return "namedpipe";
+    }
+
+    @Override
+    public String toString() {
+        return pipe;
     }
 }

--- a/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
@@ -1,0 +1,16 @@
+package com.timgroup.statsd;
+
+import java.net.SocketAddress;
+
+public class NamedPipeSocketAddress extends SocketAddress {
+    private static final String NAMED_PIPE_PREFIX = "\\\\.\\pipe\\";
+    private final String pipe;
+
+    public NamedPipeSocketAddress(String pipeName) {
+        this.pipe = pipeName.startsWith(NAMED_PIPE_PREFIX) ? pipeName : NAMED_PIPE_PREFIX + pipeName;;
+    }
+
+    public String getPipe() {
+        return pipe;
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
@@ -17,7 +17,7 @@ public class NamedPipeSocketAddress extends SocketAddress {
     /**
      * A normalized version of the pipe name that includes the `\\.\pipe\` prefix
      */
-    public static String normalizePipeName(String pipeName) {
+    static String normalizePipeName(String pipeName) {
         if (pipeName.startsWith(NAMED_PIPE_PREFIX)) {
             return pipeName;
         } else {

--- a/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeSocketAddress.java
@@ -7,10 +7,21 @@ public class NamedPipeSocketAddress extends SocketAddress {
     private final String pipe;
 
     public NamedPipeSocketAddress(String pipeName) {
-        this.pipe = pipeName.startsWith(NAMED_PIPE_PREFIX) ? pipeName : NAMED_PIPE_PREFIX + pipeName;;
+        this.pipe = normalizePipeName(pipeName);
     }
 
     public String getPipe() {
         return pipe;
+    }
+
+    /**
+     * A normalized version of the pipe name that includes the `\\.\pipe\` prefix
+     */
+    public static String normalizePipeName(String pipeName) {
+        if (pipeName.startsWith(NAMED_PIPE_PREFIX)) {
+            return pipeName;
+        } else {
+            return NAMED_PIPE_PREFIX + pipeName;
+        }
     }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1,6 +1,5 @@
 package com.timgroup.statsd;
 
-import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixSocketAddress;
 
 import java.io.IOException;
@@ -396,7 +395,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 }
             }
 
-            if (telemetryClientChannel != null) {
+            if (telemetryClientChannel != null && telemetryClientChannel != clientChannel) {
                 try {
                     telemetryClientChannel.close();
                 } catch (final IOException e) {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -5,11 +5,12 @@ import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketOptions;
 
 import java.io.IOException;
-import java.lang.Double;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -22,7 +23,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
@@ -100,7 +100,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     /**
      * UTF-8 is the expected encoding for data sent to the agent.
      */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     private static final StatsDClientErrorHandler NO_OP_HANDLER = new StatsDClientErrorHandler() {
         @Override public void handle(final Exception ex) { /* No-op */ }
@@ -154,7 +154,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
     private final String prefix;
-    private final DatagramChannel clientChannel;
+    private final ClientChannel clientChannel;
+    private final ClientChannel telemetryClientChannel;
     private final StatsDClientErrorHandler handler;
     private final String constantTagsRendered;
 
@@ -261,58 +262,27 @@ public class NonBlockingStatsDClient implements StatsDClient {
             costantPreTags = null;
         }
 
-        String transportType = "";
         try {
-            final SocketAddress address = addressLookup.call();
-            if (address instanceof UnixSocketAddress) {
-                clientChannel = UnixDatagramChannel.open();
-                // Set send timeout, to handle the case where the transmission buffer is full
-                // If no timeout is set, the send becomes blocking
-                if (timeout > 0) {
-                    clientChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
-                }
-                if (bufferSize > 0) {
-                    clientChannel.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
-                }
-                transportType = "uds";
-            } else {
-                clientChannel = DatagramChannel.open();
-                transportType = "udp";
-            }
+            clientChannel = createByteChannel(addressLookup, timeout, bufferSize);
 
             ThreadFactory threadFactory = customThreadFactory != null ? customThreadFactory : new StatsDThreadFactory();
 
             statsDProcessor = createProcessor(queueSize, handler, maxPacketSizeBytes, poolSize,
                     processorWorkers, blocking, aggregationFlushInterval, aggregationShards, threadFactory);
-            telemetryStatsDProcessor = statsDProcessor;
 
             Properties properties = new Properties();
             properties.load(getClass().getClassLoader().getResourceAsStream(
                 "dogstatsd/version.properties"));
 
-            String telemetryTags = tagString(new String[]{CLIENT_TRANSPORT_TAG + transportType,
+            String telemetryTags = tagString(new String[]{CLIENT_TRANSPORT_TAG + clientChannel.getTransportType(),
                                                           CLIENT_VERSION_TAG + properties.getProperty("dogstatsd_client_version"),
                                                           CLIENT_TAG}, new StringBuilder()).toString();
 
-            DatagramChannel telemetryClientChannel = clientChannel;
-            if (addressLookup != telemetryAddressLookup) {
-
-                final SocketAddress telemetryAddress = telemetryAddressLookup.call();
-                if (telemetryAddress instanceof UnixSocketAddress) {
-                    telemetryClientChannel = UnixDatagramChannel.open();
-                    // Set send timeout, to handle the case where the transmission buffer is full
-                    // If no timeout is set, the send becomes blocking
-                    if (timeout > 0) {
-                        telemetryClientChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
-                    }
-                    if (bufferSize > 0) {
-                        telemetryClientChannel.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
-                    }
-                } else if (transportType == "uds") {
-                    // UDP clientChannel can submit to multiple addresses, we only need
-                    // a new channel if transport type is UDS for main traffic.
-                    telemetryClientChannel = DatagramChannel.open();
-                }
+            if (addressLookup == telemetryAddressLookup) {
+                telemetryClientChannel = clientChannel;
+                telemetryStatsDProcessor = statsDProcessor;
+            } else {
+                telemetryClientChannel = createByteChannel(telemetryAddressLookup, timeout, bufferSize);
 
                 // similar settings, but a single worker and non-blocking.
                 telemetryStatsDProcessor = createProcessor(queueSize, handler, maxPacketSizeBytes,
@@ -324,16 +294,15 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 .processor(telemetryStatsDProcessor)
                 .build();
 
-            statsDSender = createSender(addressLookup, handler, clientChannel, statsDProcessor.getBufferPool(),
+            statsDSender = createSender(handler, clientChannel, statsDProcessor.getBufferPool(),
                     statsDProcessor.getOutboundQueue(), senderWorkers, threadFactory);
 
             telemetryStatsDSender = statsDSender;
             if (telemetryStatsDProcessor != statsDProcessor) {
                 // TODO: figure out why the hell telemetryClientChannel does not work here!
-                telemetryStatsDSender = createSender(telemetryAddressLookup, handler, telemetryClientChannel,
+                telemetryStatsDSender = createSender(handler, telemetryClientChannel,
                         telemetryStatsDProcessor.getBufferPool(), telemetryStatsDProcessor.getOutboundQueue(),
                         1, threadFactory);
-
             }
 
             // set telemetry
@@ -389,10 +358,10 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
     }
 
-    protected StatsDSender createSender(final Callable<SocketAddress> addressLookup, final StatsDClientErrorHandler handler,
-            final DatagramChannel clientChannel, BufferPool pool, BlockingQueue<ByteBuffer> buffers, final int senderWorkers,
+    protected StatsDSender createSender(final StatsDClientErrorHandler handler,
+            final WritableByteChannel clientChannel, BufferPool pool, BlockingQueue<ByteBuffer> buffers, final int senderWorkers,
             final ThreadFactory threadFactory) throws Exception {
-        return new StatsDSender(addressLookup, clientChannel, handler, pool, buffers, senderWorkers, threadFactory);
+        return new StatsDSender(clientChannel, handler, pool, buffers, senderWorkers, threadFactory);
     }
 
     /**
@@ -423,6 +392,14 @@ public class NonBlockingStatsDClient implements StatsDClient {
             if (clientChannel != null) {
                 try {
                     clientChannel.close();
+                } catch (final IOException e) {
+                    handler.handle(e);
+                }
+            }
+
+            if (telemetryClientChannel != null) {
+                try {
+                    telemetryClientChannel.close();
                 } catch (final IOException e) {
                     handler.handle(e);
                 }
@@ -467,6 +444,26 @@ public class NonBlockingStatsDClient implements StatsDClient {
      */
     StringBuilder tagString(final String[] tags, StringBuilder builder) {
         return tagString(tags, constantTagsRendered, builder);
+    }
+
+    ClientChannel createByteChannel(Callable<SocketAddress> addressLookup, int timeout, int bufferSize) throws Exception {
+        final SocketAddress address = addressLookup.call();
+        if (address instanceof NamedPipeSocketAddress) {
+            return new NamedPipeClientChannel((NamedPipeSocketAddress) address);
+        } else if (address instanceof UnixSocketAddress) {
+            UnixDatagramChannel unixDatagramChannel = UnixDatagramChannel.open();
+            // Set send timeout, to handle the case where the transmission buffer is full
+            // If no timeout is set, the send becomes blocking
+            if (timeout > 0) {
+                unixDatagramChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
+            }
+            if (bufferSize > 0) {
+                unixDatagramChannel.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
+            }
+            return new DatagramClientChannel(unixDatagramChannel, address);
+        } else {
+            return new DatagramClientChannel(DatagramChannel.open(), address);
+        }
     }
 
     abstract class StatsDMessage<T extends Number> extends NumericMessage<T> {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -450,16 +450,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         if (address instanceof NamedPipeSocketAddress) {
             return new NamedPipeClientChannel((NamedPipeSocketAddress) address);
         } else if (address instanceof UnixSocketAddress) {
-            UnixDatagramChannel unixDatagramChannel = UnixDatagramChannel.open();
-            // Set send timeout, to handle the case where the transmission buffer is full
-            // If no timeout is set, the send becomes blocking
-            if (timeout > 0) {
-                unixDatagramChannel.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
-            }
-            if (bufferSize > 0) {
-                unixDatagramChannel.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
-            }
-            return new DatagramClientChannel(unixDatagramChannel, address);
+            return new UnixDatagramClientChannel(address, timeout, bufferSize);
         } else {
             return new DatagramClientChannel(DatagramChannel.open(), address);
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -2,7 +2,6 @@ package com.timgroup.statsd;
 
 import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketOptions;
 
 import java.io.IOException;
 import java.net.SocketAddress;

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -54,6 +54,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
     public static final String DD_DOGSTATSD_PORT_ENV_VAR = "DD_DOGSTATSD_PORT";
     public static final String DD_AGENT_HOST_ENV_VAR = "DD_AGENT_HOST";
+    public static final String DD_NAMED_PIPE_ENV_VAR = "DD_DOGSTATSD_PIPE_NAME";
     public static final String DD_ENTITY_ID_ENV_VAR = "DD_ENTITY_ID";
     private static final String ENTITY_ID_TAG_NAME = "dd.internal.entity_id" ;
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -5,7 +5,6 @@ import jnr.unixsocket.UnixSocketAddress;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.DatagramChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -452,7 +451,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         } else if (address instanceof UnixSocketAddress) {
             return new UnixDatagramClientChannel(address, timeout, bufferSize);
         } else {
-            return new DatagramClientChannel(DatagramChannel.open(), address);
+            return new DatagramClientChannel(address);
         }
     }
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -196,13 +196,15 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
 
         int packetSize = maxPacketSizeBytes;
         Callable<SocketAddress> lookup = addressLookup;
-        Callable<SocketAddress> telemetryLookup = telemetryAddressLookup;
 
         if (lookup == null) {
-            if (namedPipe == null) {
+            String namedPipeFromEnv = System.getenv(NonBlockingStatsDClient.DD_NAMED_PIPE_ENV_VAR);
+            String resolvedNamedPipe = namedPipe == null ? namedPipeFromEnv : namedPipe;
+            
+            if (resolvedNamedPipe == null) {
                 lookup = staticStatsDAddressResolution(hostname, port);
             } else {
-                lookup = staticNamedPipeResolution(namedPipe);
+                lookup = staticNamedPipeResolution(resolvedNamedPipe);
             }
         }
 
@@ -211,7 +213,7 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
                 NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES;
         }
 
-
+        Callable<SocketAddress> telemetryLookup = telemetryAddressLookup;
         if (telemetryLookup == null) {
             if (telemetryHostname == null) {
                 telemetryLookup = lookup;

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -94,8 +94,9 @@ public class StatsDSender {
                 buffer.clear();
                 if (sizeOfBuffer != sentBytes) {
                     throw new IOException(
-                            String.format("Could not send stat %s entirely. Only sent %d out of %d bytes",
-                                    buffer.toString(),
+                            String.format("Could not send stat %s entirely to %s. Only sent %d out of %d bytes",
+                                    buffer,
+                                    clientChannel,
                                     sentBytes,
                                     sizeOfBuffer));
                 }

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -12,9 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StatsDSender {
-    private final Callable<SocketAddress> addressLookup;
-    private final SocketAddress address;
-    private final DatagramChannel clientChannel;
+    private final WritableByteChannel clientChannel;
     private final StatsDClientErrorHandler handler;
 
     private final BufferPool pool;
@@ -30,9 +29,9 @@ public class StatsDSender {
     private volatile Telemetry telemetry;
 
 
-    StatsDSender(final Callable<SocketAddress> addressLookup, final DatagramChannel clientChannel,
+    StatsDSender(final WritableByteChannel clientChannel,
                  final StatsDClientErrorHandler handler, BufferPool pool, BlockingQueue<ByteBuffer> buffers,
-                 final int workers, final ThreadFactory threadFactory) throws Exception {
+                 final int workers, final ThreadFactory threadFactory) {
 
         this.pool = pool;
         this.buffers = buffers;
@@ -40,8 +39,6 @@ public class StatsDSender {
         this.threadFactory = threadFactory;
         this.workers = new Thread[workers];
 
-        this.addressLookup = addressLookup;
-        this.address = addressLookup.call();
         this.clientChannel = clientChannel;
 
         this.endSignal = new CountDownLatch(workers);
@@ -92,14 +89,13 @@ public class StatsDSender {
                 sizeOfBuffer = buffer.position();
 
                 buffer.flip();
-                final int sentBytes = clientChannel.send(buffer, address);
+                final int sentBytes = clientChannel.write(buffer);
 
                 buffer.clear();
                 if (sizeOfBuffer != sentBytes) {
                     throw new IOException(
-                            String.format("Could not send stat %s entirely to %s. Only sent %d out of %d bytes",
+                            String.format("Could not send stat %s entirely. Only sent %d out of %d bytes",
                                     buffer.toString(),
-                                    address.toString(),
                                     sentBytes,
                                     sizeOfBuffer));
                 }

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -1,0 +1,32 @@
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import jnr.unixsocket.UnixDatagramChannel;
+import jnr.unixsocket.UnixSocketOptions;
+
+public class UnixDatagramClientChannel extends DatagramClientChannel {
+    /**
+     * Creates a new UnixDatagramClientChannel
+     *
+     * @param address Address to connect the channel to
+     * @param timeout Send timeout
+     * @param bufferSize Buffer size
+     */
+    public UnixDatagramClientChannel(SocketAddress address, int timeout, int bufferSize) throws IOException {
+        super(UnixDatagramChannel.open(), address);
+        // Set send timeout, to handle the case where the transmission buffer is full
+        // If no timeout is set, the send becomes blocking
+        if (timeout > 0) {
+            delegate.setOption(UnixSocketOptions.SO_SNDTIMEO, timeout);
+        }
+        if (bufferSize > 0) {
+            delegate.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
+        }
+    }
+
+    @Override
+    public String getTransportType() {
+        return "uds";
+    }
+}

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -13,6 +13,7 @@ public class UnixDatagramClientChannel extends DatagramClientChannel {
      * @param address Address to connect the channel to
      * @param timeout Send timeout
      * @param bufferSize Buffer size
+     * @throws IOException if socket options cannot be set
      */
     public UnixDatagramClientChannel(SocketAddress address, int timeout, int bufferSize) throws IOException {
         super(UnixDatagramChannel.open(), address);

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -1,13 +1,14 @@
 package com.timgroup.statsd;
 
-import java.io.IOException;
-import java.net.SocketAddress;
 import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixSocketOptions;
 
+import java.io.IOException;
+import java.net.SocketAddress;
+
 public class UnixDatagramClientChannel extends DatagramClientChannel {
     /**
-     * Creates a new UnixDatagramClientChannel
+     * Creates a new UnixDatagramClientChannel.
      *
      * @param address Address to connect the channel to
      * @param timeout Send timeout

--- a/src/test/java/com/timgroup/statsd/DummyLowMemStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyLowMemStatsDServer.java
@@ -2,77 +2,28 @@
 package com.timgroup.statsd;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
-import java.nio.channels.DatagramChannel;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.ArrayList;
-import java.util.List;
-import jnr.unixsocket.UnixDatagramChannel;
-import jnr.unixsocket.UnixSocketAddress;
-import java.nio.charset.StandardCharsets;
 
 
-class DummyLowMemStatsDServer extends DummyStatsDServer {
-    private final AtomicInteger packetCount = new AtomicInteger(0);
+class DummyLowMemStatsDServer extends UDPDummyStatsDServer {
     private final AtomicInteger messageCount = new AtomicInteger(0);
 
     public DummyLowMemStatsDServer(int port) throws IOException {
         super(port);
     }
 
-    public DummyLowMemStatsDServer(String socketPath) throws IOException {
-        super(socketPath);
-    }
-
-    @Override
-    protected void listen() {
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                final ByteBuffer packet = ByteBuffer.allocateDirect(1500);
-
-                while(server.isOpen()) {
-                    if (freeze) {
-                        try {
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                        }
-                    } else {
-                        try {
-                            ((Buffer)packet).clear();  // Cast necessary to handle Java9 covariant return types
-                                                       // see: https://jira.mongodb.org/browse/JAVA-2559 for ref.
-                            server.receive(packet);
-                            packet.flip();
-                            packetCount.incrementAndGet();
-
-                            for (String msg : StandardCharsets.UTF_8.decode(packet).toString().split("\n")) {
-                                messageCount.incrementAndGet();
-                            }
-                        } catch (IOException e) {
-                        }
-                    }
-                }
-            }
-        });
-        thread.setDaemon(true);
-        thread.start();
-    }
-
     @Override
     public void clear() {
-        packetCount.set(0);
         messageCount.set(0);
         super.clear();
-    }
-
-    public int getPacketCount() {
-        return packetCount.get();
     }
 
     public int getMessageCount() {
         return messageCount.get();
     }
 
+    @Override
+    protected void addMessage(String msg) {
+        messageCount.incrementAndGet();
+    }
 }

--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -3,20 +3,12 @@ package com.timgroup.statsd;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.channels.DatagramChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.LinkedBlockingQueue;
-
-import jnr.unixsocket.UnixDatagramChannel;
-import jnr.unixsocket.UnixSocketAddress;
-import java.nio.charset.StandardCharsets;
-
 
 abstract class DummyStatsDServer implements Closeable {
     private final List<String> messagesReceived = new ArrayList<String>();
@@ -70,7 +62,7 @@ abstract class DummyStatsDServer implements Closeable {
                     done = !messagesReceived.isEmpty();
                 }
 
-                if (done && prefix != null && prefix != "") {
+                if (done && prefix != null && !prefix.isEmpty()) {
                     done = false;
                     List<String> messages = this.messagesReceived();
                     for (String message : messages) {

--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -114,7 +114,10 @@ abstract class DummyStatsDServer implements Closeable {
 
     protected void addMessage(String msg) {
         synchronized(messagesReceived) {
-            messagesReceived.add(msg.trim());
+            String trimmed = msg.trim();
+            if (!trimmed.isEmpty()) {
+                messagesReceived.add(msg.trim());
+            }
         }
     }
 

--- a/src/test/java/com/timgroup/statsd/NamedPipeDummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/NamedPipeDummyStatsDServer.java
@@ -1,0 +1,70 @@
+package com.timgroup.statsd;
+
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinDef;
+import com.sun.jna.platform.win32.WinDef.DWORDByReference;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.ptr.IntByReference;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+// Template from https://github.com/java-native-access/jna/blob/master/contrib/platform/test/com/sun/jna/platform/win32/Kernel32NamedPipeTest.java
+// And https://docs.microsoft.com/en-us/windows/win32/ipc/multithreaded-pipe-server
+public class NamedPipeDummyStatsDServer extends DummyStatsDServer {
+    private final HANDLE hNamedPipe;
+    private volatile boolean clientConnected = false;
+    private volatile boolean isOpen = true;
+
+    public NamedPipeDummyStatsDServer(String pipeName) {
+        String normalizedPipeName = NamedPipeSocketAddress.normalizePipeName(pipeName);
+
+        hNamedPipe= Kernel32.INSTANCE.CreateNamedPipe(normalizedPipeName,
+                WinBase.PIPE_ACCESS_DUPLEX,        // dwOpenMode
+                WinBase.PIPE_TYPE_BYTE | WinBase.PIPE_READMODE_BYTE | WinBase.PIPE_WAIT,    // dwPipeMode
+                1,    // nMaxInstances,
+                Byte.MAX_VALUE,    // nOutBufferSize,
+                Byte.MAX_VALUE,    // nInBufferSize,
+                1000,    // nDefaultTimeOut,
+                null);    // lpSecurityAttributes
+
+        if (WinBase.INVALID_HANDLE_VALUE.equals(hNamedPipe)) {
+            throw new RuntimeException("Unable to create named pipe");
+        }
+
+        listen();
+    }
+    @Override
+    protected boolean isOpen() {
+        return isOpen;
+    }
+
+    @Override
+    protected void receive(ByteBuffer packet) throws IOException {
+        if (!clientConnected) {
+            boolean connected = Kernel32.INSTANCE.ConnectNamedPipe(hNamedPipe, null);
+            if (connected) {
+                clientConnected = true;
+            } else {
+                close();
+                return;
+            }
+        }
+
+        IntByReference bytesRead = new IntByReference();
+        boolean success = Kernel32.INSTANCE.ReadFile(
+                hNamedPipe,        // handle to pipe
+                packet.array(),    // buffer to receive data
+                packet.remaining(), // size of buffer
+                bytesRead, // number of bytes read
+                null);        // not overlapped I/O
+        packet.position(bytesRead.getValue());
+    }
+
+    @Override
+    public void close() throws IOException {
+        isOpen = false;
+        Kernel32.INSTANCE.CloseHandle(hNamedPipe);
+    }
+}

--- a/src/test/java/com/timgroup/statsd/NamedPipeTest.java
+++ b/src/test/java/com/timgroup/statsd/NamedPipeTest.java
@@ -1,0 +1,67 @@
+package com.timgroup.statsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class NamedPipeTest implements StatsDClientErrorHandler {
+    private static final Random random = new Random();
+    private NonBlockingStatsDClient client;
+    private DummyStatsDServer server;
+    private volatile Exception lastException = new Exception();
+
+    public synchronized void handle(Exception exception) {
+        lastException = exception;
+    }
+
+    @BeforeClass
+    public static void supportedOnly() {
+        Assume.assumeTrue(System.getProperty("os.name").toLowerCase().contains("windows"));
+    }
+
+    @Before
+    public void start() {
+        String pipeName = "testPipe-" + random.nextInt(10000);
+
+        server = new NamedPipeDummyStatsDServer(pipeName);
+        client = new NonBlockingStatsDClientBuilder().prefix("my.prefix")
+            .namedPipe(pipeName)
+            .port(0)
+            .queueSize(1)
+            .timeout(1)  // non-zero timeout to ensure exception triggered if socket buffer full.
+            .socketBufferSize(1024 * 1024)
+            .enableAggregation(false)
+            .errorHandler(this)
+            .build();
+    }
+
+    @After
+    public void stop() throws IOException {
+        if (client != null) {
+            client.stop();
+        }
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_to_statsd() {
+        for(long i = 0; i < 5 ; i++) {
+            client.gauge("mycount", i);
+            server.waitForMessage();
+            String expected = String.format("my.prefix.mycount:%d|g", i);
+            assertThat(server.messagesReceived(), contains(expected));
+            server.clear();
+        }
+        assertThat(lastException.getMessage(), nullValue());
+    }
+}

--- a/src/test/java/com/timgroup/statsd/NamedPipeTest.java
+++ b/src/test/java/com/timgroup/statsd/NamedPipeTest.java
@@ -33,7 +33,6 @@ public class NamedPipeTest implements StatsDClientErrorHandler {
 
     @Before
     public void start() {
-        log.info("starting test");
         String pipeName = "testPipe-" + random.nextInt(10000);
 
         server = new NamedPipeDummyStatsDServer(pipeName);

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientMaxPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientMaxPerfTest.java
@@ -156,6 +156,6 @@ public final class NonBlockingStatsDClientMaxPerfTest {
         executor.awaitTermination(1, TimeUnit.SECONDS);
 
         assertNotEquals(0, server.getMessageCount());
-        log.info("Messages at server: " + server.getMessageCount() + " packets: " + server.getPacketCount());
+        log.info("Messages at server: " + server.getMessageCount() + " packets: " + server.getPacketsReceived());
     }
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -92,25 +92,16 @@ public final class NonBlockingStatsDClientPerfTest {
     public void perfAggregatedTest() throws Exception {
 
         int expectedSize = 1;
-        long elapsed = 0, start = System.currentTimeMillis();
-        boolean done = false;
+        long start = System.currentTimeMillis();
 
-        while(!done) {
+        while(System.currentTimeMillis() - start < clientAggr.statsDProcessor.getAggregator().getFlushInterval() - 1) {
             clientAggr.count("myaggrcount", 1);
-
-            elapsed = System.currentTimeMillis() - start;
-            if  (elapsed > clientAggr.statsDProcessor.getAggregator().getFlushInterval() - 1) {
-                done = true;
-            }
             Thread.sleep(50);
         }
 
-
-        int messages;
-        while((messages = server.messagesReceived().size()) < expectedSize) {
-
+        while(server.messagesReceived().size() < expectedSize) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(50);
             } catch (InterruptedException ex) {}
         }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -43,7 +43,7 @@ public final class NonBlockingStatsDClientPerfTest {
 
     @BeforeClass
     public static void start() throws IOException {
-        server = new DummyStatsDServer(STATSD_SERVER_PORT);
+        server = new UDPDummyStatsDServer(STATSD_SERVER_PORT);
     }
 
     @AfterClass

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -41,7 +41,7 @@ public class NonBlockingStatsDClientTest {
 
     @BeforeClass
     public static void start() throws IOException {
-        server = new DummyStatsDServer(STATSD_SERVER_PORT);
+        server = new UDPDummyStatsDServer(STATSD_SERVER_PORT);
         client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
@@ -1108,7 +1108,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout=5000L)
     public void sends_telemetry_elsewhere() throws Exception {
         final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final DummyStatsDServer telemetryServer = new DummyStatsDServer(STATSD_SERVER_PORT+10);
+        final DummyStatsDServer telemetryServer = new UDPDummyStatsDServer(STATSD_SERVER_PORT+10);
         final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
@@ -1379,7 +1379,7 @@ public class NonBlockingStatsDClientTest {
     public void shutdown_test() throws Exception {
         final int port = 17256;
         final int qSize = 256;
-        final DummyStatsDServer server = new DummyStatsDServer(port);
+        final DummyStatsDServer server = new UDPDummyStatsDServer(port);
 
         final NonBlockingStatsDClientBuilder builder = new SlowStatsDNonBlockingStatsDClientBuilder().prefix("")
             .hostname("localhost")
@@ -1480,7 +1480,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void nonsampling_client_test() throws Exception {
         final int port = 17256;
-        final DummyStatsDServer server = new DummyStatsDServer(port);
+        final DummyStatsDServer server = new UDPDummyStatsDServer(port);
 
 	final NonBlockingStatsDClientBuilder builder = new NonsamplingClientBuilder()
 	    .prefix("")

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -85,6 +85,7 @@ public class TelemetryTest {
             .hostname("localhost")
             .constantTags("test")
             .port(STATSD_SERVER_PORT)
+            .enableAggregation(false)
             .enableTelemetry(false);  // disable telemetry so we can control calls to "flush"
     private static NonBlockingStatsDClient telemetryClient = telemetryBuilder.build();
 

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -2,6 +2,7 @@ package com.timgroup.statsd;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -73,87 +74,23 @@ public class TelemetryTest {
         }
     }
 
-    // StatsDNonBlockingTelemetry exposes the telemetry tor the outside
-    private static class StatsDNonBlockingTelemetry extends NonBlockingStatsDClient {
-        public StatsDNonBlockingTelemetry(final String prefix, final int queueSize, String[] constantTags,
-                                       final StatsDClientErrorHandler errorHandler, Callable<SocketAddress> addressLookup,
-                                       final int timeout, final int bufferSize, final int maxPacketSizeBytes,
-                                       String entityID, final int poolSize, final int processorWorkers,
-                                       final int senderWorkers, boolean blocking, final boolean enableTelemetry,
-                                       final int telemetryFlushInterval)
-                throws StatsDClientException {
-
-            super(new NonBlockingStatsDClientBuilder()
-                .prefix(prefix)
-                .queueSize(queueSize)
-                .constantTags(constantTags)
-                .errorHandler(errorHandler)
-                .addressLookup(addressLookup)
-                .timeout(timeout)
-                .socketBufferSize(bufferSize)
-                .maxPacketSizeBytes(maxPacketSizeBytes)
-                .entityID(entityID)
-                .bufferPoolSize(poolSize)
-                .processorWorkers(processorWorkers)
-                .senderWorkers(senderWorkers)
-                .blocking(blocking)
-                .enableTelemetry(enableTelemetry)
-                .telemetryFlushInterval(telemetryFlushInterval)
-                .resolve());
-        }
-    };
-
-    private static class StatsDNonBlockingTelemetryBuilder extends NonBlockingStatsDClientBuilder {
-
-        @Override
-        public StatsDNonBlockingTelemetry build() throws StatsDClientException {
-
-            int packetSize = maxPacketSizeBytes;
-            if (packetSize == 0) {
-                packetSize = (port == 0) ? NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES :
-                    NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES;
-            }
-
-            if (addressLookup != null) {
-                return new StatsDNonBlockingTelemetry(prefix, queueSize, constantTags, errorHandler,
-                        addressLookup, timeout, socketBufferSize, packetSize, entityID,
-                        bufferPoolSize, processorWorkers, senderWorkers, blocking, enableTelemetry,
-                        telemetryFlushInterval);
-            } else {
-                return new StatsDNonBlockingTelemetry(prefix, queueSize, constantTags, errorHandler,
-                        staticStatsDAddressResolution(hostname, port), timeout, socketBufferSize, packetSize,
-                        entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking, enableTelemetry,
-                        telemetryFlushInterval);
-            }
-        }
-    }
-
     private static final int STATSD_SERVER_PORT = 17254;
-    private static final NonBlockingStatsDClientBuilder builder = new StatsDNonBlockingTelemetryBuilder()
+    private static final NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder()
         .prefix("my.prefix")
         .hostname("localhost")
         .constantTags("test")
         .port(STATSD_SERVER_PORT)
         .enableTelemetry(false); // disable telemetry so we can control calls to "flush"
-    private static StatsDNonBlockingTelemetry client = ((StatsDNonBlockingTelemetryBuilder)builder).build();
+    private static NonBlockingStatsDClient client = builder.build();
 
     // telemetry client
-    private static final NonBlockingStatsDClientBuilder telemetryBuilder = new StatsDNonBlockingTelemetryBuilder()
+    private static final NonBlockingStatsDClientBuilder telemetryBuilder = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
             .constantTags("test")
             .port(STATSD_SERVER_PORT)
             .enableTelemetry(false);  // disable telemetry so we can control calls to "flush"
-    private static StatsDNonBlockingTelemetry telemetryClient = ((StatsDNonBlockingTelemetryBuilder)telemetryBuilder).build();
-
-    // builderError fails to send any data on the network, producing packets dropped
-    private static final NonBlockingStatsDClientBuilder builderError = new StatsDNonBlockingTelemetryBuilder()
-        .prefix("my.prefix")
-        .hostname("localhost")
-        .constantTags("test")
-        .port(0)
-        .enableTelemetry(false); // disable telemetry so we can control calls to "flush"
-    private static StatsDNonBlockingTelemetry clientError = ((StatsDNonBlockingTelemetryBuilder)builderError).build();
+    private static NonBlockingStatsDClient telemetryClient = telemetryBuilder.build();
 
     private static DummyStatsDServer server;
     private static FakeProcessor fakeProcessor;
@@ -181,7 +118,6 @@ public class TelemetryTest {
     public static void stop() throws Exception {
         try {
             client.stop();
-            clientError.stop();
             server.close();
         } catch (java.io.IOException e) {
             return;
@@ -192,7 +128,6 @@ public class TelemetryTest {
     public void clear() {
         server.clear();
         client.telemetry.reset();
-        clientError.telemetry.reset();
         telemetryClient.telemetry.reset();
         fakeProcessor.clear();
     }
@@ -437,7 +372,18 @@ public class TelemetryTest {
 
     @Test(timeout = 5000L)
     public void telemetry_droppedData() throws Exception {
-        clientError.telemetry.reset();
+        boolean isLinux = System.getProperty("os.name").toLowerCase().contains("linux");
+        boolean isMac = System.getProperty("os.name").toLowerCase().contains("mac");
+        Assume.assumeTrue(isLinux || isMac);
+
+        // fails to send any data on the network, producing packets dropped
+        NonBlockingStatsDClient clientError = new NonBlockingStatsDClientBuilder()
+                .prefix("my.prefix")
+                .hostname("localhost")
+                .constantTags("test")
+                .port(0)
+                .enableTelemetry(false) // disable telemetry so we can control calls to "flush"
+                .build();
 
         assertThat(clientError.statsDProcessor.bufferPool.getBufferSize(), equalTo(8192));
 
@@ -451,6 +397,8 @@ public class TelemetryTest {
                 Thread.sleep(50L);
             } catch (InterruptedException e) {}
         }
+
+        clientError.stop();
 
         assertThat(clientError.telemetry.metricsSent.get(), equalTo(1));
         assertThat(clientError.telemetry.packetsDropped.get(), equalTo(1));

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -169,7 +169,7 @@ public class TelemetryTest {
 
     @BeforeClass
     public static void start() throws IOException, Exception {
-        server = new DummyStatsDServer(STATSD_SERVER_PORT);
+        server = new UDPDummyStatsDServer(STATSD_SERVER_PORT);
         fakeProcessor = new FakeProcessor(NO_OP_HANDLER);
         client.telemetry.processor = fakeProcessor;
         telemetryClient.telemetry.processor = fakeProcessor;

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -7,8 +7,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.SocketAddress;
-import java.util.concurrent.Callable;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -16,8 +14,6 @@ import java.util.Properties;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 
 public class TelemetryTest {

--- a/src/test/java/com/timgroup/statsd/UDPDummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/UDPDummyStatsDServer.java
@@ -1,0 +1,34 @@
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+
+public class UDPDummyStatsDServer extends DummyStatsDServer {
+    private final DatagramChannel server;
+
+    public UDPDummyStatsDServer(int port) throws IOException {
+        server = DatagramChannel.open();
+        server.bind(new InetSocketAddress(port));
+        this.listen();
+    }
+
+    @Override
+    protected boolean isOpen() {
+        return server.isOpen();
+    }
+
+    @Override
+    protected void receive(ByteBuffer packet) throws IOException {
+        server.receive(packet);
+    }
+
+    public void close() throws IOException {
+        try {
+            server.close();
+        } catch (Exception e) {
+            //ignore
+        }
+    }
+}

--- a/src/test/java/com/timgroup/statsd/UnixSocketDummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketDummyStatsDServer.java
@@ -1,0 +1,34 @@
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import jnr.unixsocket.UnixDatagramChannel;
+import jnr.unixsocket.UnixSocketAddress;
+
+public class UnixSocketDummyStatsDServer extends DummyStatsDServer {
+    private final DatagramChannel server;
+
+    public UnixSocketDummyStatsDServer(String socketPath) throws IOException {
+        server = UnixDatagramChannel.open();
+        server.bind(new UnixSocketAddress(socketPath));
+        this.listen();
+    }
+    @Override
+    protected boolean isOpen() {
+        return server.isOpen();
+    }
+
+    @Override
+    protected void receive(ByteBuffer packet) throws IOException {
+        server.receive(packet);
+    }
+
+    public void close() throws IOException {
+        try {
+            server.close();
+        } catch (Exception e) {
+            //ignore
+        }
+    }
+}

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -47,7 +47,7 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         socketFile = new File(tmpFolder, "socket.sock");
         socketFile.deleteOnExit();
 
-        server = new DummyStatsDServer(socketFile.toString());
+        server = new UnixSocketDummyStatsDServer(socketFile.toString());
         client = new NonBlockingStatsDClientBuilder().prefix("my.prefix")
             .hostname(socketFile.toString())
             .port(0)
@@ -120,7 +120,7 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
 
         // Re-open the server, next send should work OK
         lastException = new Exception();
-        DummyStatsDServer server2 = new DummyStatsDServer(socketFile.toString());
+        DummyStatsDServer server2 = new UnixSocketDummyStatsDServer(socketFile.toString());
 
         client.gauge("mycount", 30);
         server2.waitForMessage();


### PR DESCRIPTION
This PR adds named pipe support for windows machines. Named pipes are similar to unix domain sockets. This PR supports submitting metrics to Datadog in Azure App Services (https://github.com/DataDog/datadog-aas-extension).

The main changes are:
* Abstracting `DatagramChannel` into the `ClientChannel` interface
* Adding a `ClientChannel` implementation for named pipes
* Adding configuration support in the builder
* Subclassing `DummyStatsD` server for testing of the 3 transport types

Unfortunately, only *existing* named pipes can be written to in pure Java. In order to create named pipes for testing, JNA is used.