### PR TITLE
Re-enable aggregation by default

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -90,7 +90,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     public static final boolean DEFAULT_BLOCKING = false;
     public static final boolean DEFAULT_ENABLE_TELEMETRY = true;
 
-    public static final boolean DEFAULT_ENABLE_AGGREGATION = false;
+    public static final boolean DEFAULT_ENABLE_AGGREGATION = true;
 
     public static final String CLIENT_TAG = "client:java";
     public static final String CLIENT_VERSION_TAG = "client_version:";

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -97,6 +97,7 @@ public class TelemetryTest {
                 .processorWorkers(processorWorkers)
                 .senderWorkers(senderWorkers)
                 .blocking(blocking)
+                .enableAggregation(false)
                 .enableTelemetry(enableTelemetry)
                 .telemetryFlushInterval(telemetryFlushInterval)
                 .resolve());


### PR DESCRIPTION
Setting was enabled by default in #158, but this change was reverted by accident when #157 was merged.