### PR TITLE
Remove unnecessary public

### DIFF
--- a/src/main/java/com/timgroup/statsd/ClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/ClientChannel.java
@@ -2,6 +2,6 @@ package com.timgroup.statsd;
 
 import java.nio.channels.WritableByteChannel;
 
-public interface ClientChannel extends WritableByteChannel {
+interface ClientChannel extends WritableByteChannel {
     String getTransportType();
 }

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -5,7 +5,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 
-public class DatagramClientChannel implements ClientChannel {
+class DatagramClientChannel implements ClientChannel {
     protected final DatagramChannel delegate;
     private final SocketAddress address;
 
@@ -14,7 +14,7 @@ public class DatagramClientChannel implements ClientChannel {
      * @param address Address to connect the channel to
      * @throws IOException if an I/O error occurs
      */
-    public DatagramClientChannel(SocketAddress address) throws IOException {
+    DatagramClientChannel(SocketAddress address) throws IOException {
         this(DatagramChannel.open(), address);
     }
 
@@ -23,7 +23,7 @@ public class DatagramClientChannel implements ClientChannel {
      * @param delegate Implementation this instance wraps
      * @param address Address to connect the channel to
      */
-    public DatagramClientChannel(DatagramChannel delegate, SocketAddress address) {
+    DatagramClientChannel(DatagramChannel delegate, SocketAddress address) {
         this.delegate = delegate;
         this.address = address;
     }

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -6,7 +6,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-public class NamedPipeClientChannel implements ClientChannel {
+class NamedPipeClientChannel implements ClientChannel {
     private final RandomAccessFile randomAccessFile;
     private final FileChannel fileChannel;
     private final String pipe;
@@ -17,7 +17,7 @@ public class NamedPipeClientChannel implements ClientChannel {
      * @param address Location of named pipe
      * @throws FileNotFoundException if pipe does not exist
      */
-    public NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
+    NamedPipeClientChannel(NamedPipeSocketAddress address) throws FileNotFoundException {
         pipe = address.getPipe();
         randomAccessFile = new RandomAccessFile(pipe, "rw");
         fileChannel = randomAccessFile.getChannel();

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -6,7 +6,7 @@ import jnr.unixsocket.UnixSocketOptions;
 import java.io.IOException;
 import java.net.SocketAddress;
 
-public class UnixDatagramClientChannel extends DatagramClientChannel {
+class UnixDatagramClientChannel extends DatagramClientChannel {
     /**
      * Creates a new UnixDatagramClientChannel.
      *
@@ -15,7 +15,7 @@ public class UnixDatagramClientChannel extends DatagramClientChannel {
      * @param bufferSize Buffer size
      * @throws IOException if socket options cannot be set
      */
-    public UnixDatagramClientChannel(SocketAddress address, int timeout, int bufferSize) throws IOException {
+    UnixDatagramClientChannel(SocketAddress address, int timeout, int bufferSize) throws IOException {
         super(UnixDatagramChannel.open(), address);
         // Set send timeout, to handle the case where the transmission buffer is full
         // If no timeout is set, the send becomes blocking


### PR DESCRIPTION
Client channel is an implementation detail of the client, and the method where
the channel classes are used is private. There is no need for these classes to
be public.

Modified files were added in #169 and were never released yet.