### PR TITLE
Flush buffers on close

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -166,6 +166,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     protected final Telemetry telemetry;
 
     private final boolean blocking;
+
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
      * specified host and port. All messages send via this client will have
@@ -368,7 +369,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * Cleanly shut down this StatsD client. This method may throw an exception if
      * the socket cannot be closed.
      *
-     * In blocking mode, this will block until all messages are sent to the server.
+     * <p>In blocking mode, this will block until all messages are sent to the server.
      */
     @Override
     public void stop() {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -165,6 +165,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     protected StatsDSender telemetryStatsDSender;
     protected final Telemetry telemetry;
 
+    private final boolean blocking;
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
      * specified host and port. All messages send via this client will have
@@ -236,6 +237,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             handler = errorHandler;
         }
 
+        this.blocking = blocking;
         {
             List<String> costantPreTags = new ArrayList<>();
             if (constantTags != null) {
@@ -365,25 +367,21 @@ public class NonBlockingStatsDClient implements StatsDClient {
     /**
      * Cleanly shut down this StatsD client. This method may throw an exception if
      * the socket cannot be closed.
+     *
+     * In blocking mode, this will block until all messages are sent to the server.
      */
     @Override
     public void stop() {
         try {
             this.telemetry.stop();
-            statsDProcessor.shutdown();
-            statsDSender.shutdown();
+            statsDProcessor.shutdown(blocking);
+            statsDSender.shutdown(blocking);
 
             // shut down telemetry workers if need be
             if (telemetryStatsDProcessor != statsDProcessor) {
-                telemetryStatsDProcessor.shutdown();
-                telemetryStatsDSender.shutdown();
+                telemetryStatsDProcessor.shutdown(false);
+                telemetryStatsDSender.shutdown(false);
             }
-
-            long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
-
-            statsDProcessor.awaitUntil(deadline);
-            statsDSender.awaitUntil(deadline);
-
         } catch (final Exception e) {
             handler.handle(e);
         } finally {

--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -120,20 +120,13 @@ public class StatsDSender {
         }
     }
 
-    void shutdown() {
+    void shutdown(boolean blocking) throws InterruptedException {
         shutdown = true;
-        for (int i = 0 ; i < workers.length ; i++) {
-            workers[i].interrupt();
-        }
-    }
-
-    boolean awaitUntil(final long deadline) {
-        while (true) {
-            long remaining = deadline - System.currentTimeMillis();
-            try {
-                return endSignal.await(remaining, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                // check again...
+        if (blocking) {
+            endSignal.await();
+        } else {
+            for (int i = 0 ; i < workers.length ; i++) {
+                workers[i].interrupt();
             }
         }
     }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -11,6 +11,8 @@ import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -1499,5 +1501,43 @@ public class NonBlockingStatsDClientTest {
             client.stop();
             server.close();
         }
+    }
+
+    // Test that in the blocking mode metrics are written out to the socket before close() returns.
+    volatile boolean blocking_close_sent = false;
+    @Test(timeout = 5000L)
+    public void blocking_close_test() throws Exception {
+        final int port = 17256;
+        final byte[] expect = "test:1|g\n".getBytes(StandardCharsets.UTF_8);
+        NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder() {
+                @Override
+                public NonBlockingStatsDClient build() {
+                    return new NonBlockingStatsDClient(resolve()) {
+                        @Override
+                        ClientChannel createByteChannel(Callable<SocketAddress> addressLookup, int timeout, int bufferSize) throws Exception {
+                            return new DatagramClientChannel(addressLookup.call()) {
+                                @Override
+                                public int write(ByteBuffer data) throws IOException {
+                                    // The test should pass without the sleep, but if there is a
+                                    // race with the assert below, make it worse.
+                                    try {
+                                        Thread.sleep(100);
+                                    } catch (InterruptedException e) {
+                                        return 0;
+                                    }
+                                    boolean sent = data.equals(ByteBuffer.wrap(expect));
+                                    int n = super.write(data);
+                                    blocking_close_sent = sent;
+                                    return n;
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+        NonBlockingStatsDClient client = builder.hostname("localhost").port(port).blocking(true).build();
+        client.gauge("test", 1);
+        client.close();
+        assertEquals(true, blocking_close_sent);
     }
 }

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -115,6 +115,12 @@ public class StatsDAggregatorTest {
                     messageSent.incrementAndGet();
                 }
             }
+
+            @Override
+            Message getMessage() { return null; }
+
+            @Override
+            boolean haveMessages() { return false; }
         }
 
         @Override
@@ -158,7 +164,11 @@ public class StatsDAggregatorTest {
 
     @AfterClass
     public static void stop() {
-        fakeProcessor.shutdown();
+        try {
+            fakeProcessor.shutdown(false);
+        } catch (InterruptedException e) {
+            return;
+        }
     }
 
     @After

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -33,6 +33,10 @@ public class TelemetryTest {
         private class FakeProcessingTask extends StatsDProcessor.ProcessingTask {
             @Override
             protected void processLoop() {}
+
+            @Override Message getMessage() { return null; }
+
+            @Override boolean haveMessages() { return false; }
         }
 
         @Override


### PR DESCRIPTION
If the client was created in blocking mode, flush internal buffers and queues when `.close()` or `.stop()` are called. These methods will block until all payloads are sent.