### PR TITLE
Fix security issue SNYK-JAVA-COMGITHUBJNR-1570422 by upgrading jnr-unixsocket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
-            <version>0.36</version>
+            <version>0.38.15</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Snyk scan for my service reports the following vulnerability:
```
  ✗ Use After Free [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422] in com.github.jnr:jnr-posix@3.0.61
    introduced by com.foo:barlib_2.13@0.1.0-SNAPSHOT > com.avast.cloud:datadog4s-statsd_2.13@0.31.1 > com.datadoghq:java-dogstatsd-client@3.0.0 > com.github.jnr:jnr-unixsocket@0.36 > com.github.jnr:jnr-posix@3.0.61 and 2 other path(s)
  This issue was fixed in versions: 3.1.8
```
Address this issue by upgrading jnr-unixsocket to v0.38.15 that in turn depends on jnr-posix v3.1.14.