### PR TITLE
Allow jnr-unixsocket version to be overridden or excluded by downstream dependenencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       MVN_EXTRA_OPTS: -Dcheckstyle.version=2.15 -Dcheckstyle.skip
     <<: *default_steps
   openjdk8:
-    docker:
+    docker: &jdk8
       - image: circleci/openjdk:8u242
     <<: *default_steps
   openjdk9:
@@ -57,6 +57,18 @@ jobs:
       - run: |
           mvn clean install
 
+  openjdk8-jnr-exclude:
+    docker: *jdk8
+    steps:
+      - checkout
+      - run: "mvn -Pjnr-exclude clean test"
+  openjdk8-jnr-latest:
+     docker: *jdk8
+     steps:
+       - checkout
+       - run: "mvn clean test -DskipTests" # build main and test with default deps
+       - run: "mvn -Pjnr-latest test"      # run with modified deps
+
 workflows:
   version: 2
   agent-tests:
@@ -67,3 +79,5 @@ workflows:
       - openjdk11
       - openjdk13
       - windows-openjdk12
+      - openjdk8-jnr-exclude
+      - openjdk8-jnr-latest

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,43 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Use -X option to see classpath -->
+        <profile>
+            <id>jnr-exclude</id>
+            <!-- Compile main and test code with jnr-unixsocket in classpath, but drop it when
+                 running tests. Make sure UDP and Windows support works even if jnr-unixsocket
+                 dependency is not available.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <configuration>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>com.github.jnr:jnr-unixsocket</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jnr-latest</id>
+            <!-- This profile is for testing for compatibility with the latest version of
+                 jnr-unixsocket. Maven does not rebuild main or test code when profile changes,
+                 so we can test how the code compiled with version X runs with version Y.
+            -->
+            <dependencies>
+                 <dependency>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-unixsocket</artifactId>
+                    <version>0.38.15</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -1,7 +1,5 @@
 package com.timgroup.statsd;
 
-import jnr.unixsocket.UnixSocketAddress;
-
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -448,11 +446,16 @@ public class NonBlockingStatsDClient implements StatsDClient {
         final SocketAddress address = addressLookup.call();
         if (address instanceof NamedPipeSocketAddress) {
             return new NamedPipeClientChannel((NamedPipeSocketAddress) address);
-        } else if (address instanceof UnixSocketAddress) {
-            return new UnixDatagramClientChannel(address, timeout, bufferSize);
-        } else {
-            return new DatagramClientChannel(address);
         }
+        try {
+            if (Class.forName("jnr.unixsocket.UnixSocketAddress").isInstance(address)) {
+                return new UnixDatagramClientChannel(address, timeout, bufferSize);
+            }
+        } catch (ClassNotFoundException e) {
+            // not loaded, can't use
+        }
+
+        return new DatagramClientChannel(address);
     }
 
     abstract class StatsDMessage<T extends Number> extends NumericMessage<T> {

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -243,15 +243,19 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
      * @return a function to perform the lookup
      */
     public static Callable<SocketAddress> volatileAddressResolution(final String hostname, final int port) {
-        return new Callable<SocketAddress>() {
-            @Override public SocketAddress call() throws UnknownHostException {
-                if (port == 0) { // Hostname is a file path to the socket
+        if (port == 0) {
+            return new Callable<SocketAddress>() {
+                @Override public SocketAddress call() throws UnknownHostException {
                     return new UnixSocketAddress(hostname);
-                } else {
+                }
+            };
+        } else {
+            return new Callable<SocketAddress>() {
+                @Override public SocketAddress call() throws UnknownHostException {
                     return new InetSocketAddress(InetAddress.getByName(hostname), port);
                 }
-            }
-        };
+            };
+        }
     }
 
     /**

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -369,9 +369,7 @@ public class TelemetryTest {
 
     @Test(timeout = 5000L)
     public void telemetry_droppedData() throws Exception {
-        boolean isLinux = System.getProperty("os.name").toLowerCase().contains("linux");
-        boolean isMac = System.getProperty("os.name").toLowerCase().contains("mac");
-        Assume.assumeTrue(isLinux || isMac);
+        Assume.assumeTrue(UnixSocketTest.isUdsAvailable());
 
         // fails to send any data on the network, producing packets dropped
         NonBlockingStatsDClient clientError = new NonBlockingStatsDClientBuilder()


### PR DESCRIPTION
With refactor from fb4cd25066ce6c1820dac7b439da551c648f3c35 the amount of changes necessary to make jnr-unixsocket optional at runtime is fairly small, and we don't need to rely on reflection at all.

Rest of the PR is adding tests for this scenario. UDS-related tests are adjusted to skip if UDS is not available at runtime; but everything else should run as before. A new maven profile is added that drops jnr-unixsocket from classpath only when running tests. This would be similar to how things are for our library if downstream excludes jnr-unixsocket dependency.

Latest jnr-unixsocket version, 0.38.15, appears to be backwards compatible, and can be used in-place of 0.36 which we depend on currently. To help users that want to use later version, run the test suite against a newer version as well.

Lastly, this adds two new CI jobs to run the above.