### PR TITLE
Fix concurrent modification issue

### DIFF
--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -36,7 +36,7 @@ public class TelemetryTest {
         }
 
         @Override
-        public boolean send(final Message msg) {
+        public synchronized boolean send(final Message msg) {
             messages.add(msg);
             return true;
         }
@@ -52,7 +52,7 @@ public class TelemetryTest {
             return messages;
         }
 
-        protected List<String> getMessagesAsStrings() {
+        protected synchronized List<String> getMessagesAsStrings() {
             StringBuilder sb = new StringBuilder();
             ArrayList<String> stringMessages = new ArrayList<>(messages.size());
             for(Message m : messages) {


### PR DESCRIPTION
`send()` is called by telemetry flush timer task on a separate thread, while getMessagesAsStrings() is called from the main test thread.

When moons align, flush task will still be running (`telemetry.stop()` only cancels future tasks), and `getMessagesAsStrings()` gets called at the same time `flush()` is calling `send()` to deliver metrics.