### PR TITLE
Don't report the expected InterruptedException

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -66,7 +66,6 @@ public abstract class StatsDProcessor {
             try {
                 sendBuffer = bufferPool.borrow();
             } catch (final InterruptedException e) {
-                handler.handle(e);
                 return;
             }
 


### PR DESCRIPTION
Processor thread is interrupted when the client is requested to
shutdown. That this may result in an InterruptedException is
expected, and the exception is already handled appropriately. We just
don't need to report it to he user handler, as it doesn't represent an
error condition in the code (and we don't report it in other places too).