### PR TITLE
Fix Message.equals

### DIFF
--- a/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
+++ b/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
@@ -55,7 +55,7 @@ public abstract class AlphaNumericMessage extends Message {
 
         if (object instanceof AlphaNumericMessage ) {
             AlphaNumericMessage msg = (AlphaNumericMessage)object;
-            return super.equals(msg) && (this.value == msg.getValue());
+            return super.equals(msg) && (this.value.equals(msg.getValue()));
         }
 
         return false;

--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -138,7 +138,7 @@ public abstract class Message {
         if (object instanceof Message) {
             final Message msg = (Message)object;
 
-            boolean equals = (this.getAspect() == msg.getAspect())
+            boolean equals = (Objects.equals(this.getAspect(), msg.getAspect()))
                 && (this.getType() == msg.getType())
                 && (this.done == msg.getDone())
                 && Arrays.equals(this.tags, (msg.getTags()));

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1389,6 +1389,11 @@ public class NonBlockingStatsDClientTest {
                 builder.append(this.value);
             };
         };
+        StatsDTestMessage previousNewAspectString = new StatsDTestMessage<Long>(new String("my.count"), Message.Type.COUNT, Long.valueOf(1), 0, new String[0]) {
+            @Override protected void writeValue(StringBuilder builder) {
+                builder.append(this.value);
+            };
+        };
         StatsDTestMessage previousTagged =
             new StatsDTestMessage<Long>("my.count", Message.Type.COUNT, Long.valueOf(1), 0, new String[] {"foo", "bar"}) {
 
@@ -1412,6 +1417,23 @@ public class NonBlockingStatsDClientTest {
 
         assertEquals(previous.hashCode(), next.hashCode());
         assertEquals(previousTagged.hashCode(), nextTagged.hashCode());
+        assertEquals(previous.hashCode(), previousNewAspectString.hashCode());
+        assertEquals(previous, previousNewAspectString);
+
+        class TestAlphaNumericMessage extends AlphaNumericMessage {
+            public TestAlphaNumericMessage(String aspect, Type type, String value, String[] tags) {
+                super(aspect, type, value, tags);
+            }
+
+            @Override
+            void writeTo(StringBuilder builder, String containerID) {
+
+            }
+        }
+        AlphaNumericMessage alphaNum1 = new TestAlphaNumericMessage("my.count", Message.Type.COUNT, "value", new String[] {"tag"});
+        AlphaNumericMessage alphaNum2 = new TestAlphaNumericMessage(new String("my.count"), Message.Type.COUNT, new String("value"), new String[]{new String("tag")});
+        assertEquals(alphaNum1, alphaNum2);
+
     }
 
     @Test(timeout = 5000L)


### PR DESCRIPTION
I noticed excessive CPU usage in HashMap lookups in StatsDAggregator.
The stacks shows that the HashMap had devolved into a TreeMap which
happens after frequent hash collisions. That got me looking at the
implementations of hashCode/equals in the Message heirarchy and
this seems a likely culprit.