### PR TITLE
Add an Automatic-Module-Name entry to the MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <!-- even though this isn't a true JPMS modular jar, make it play well -->
+                            <!-- with applications that want to use it as one -->
+                            <Automatic-Module-Name>com.datadoghq.dogstatsd.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${checkstyle.version}</version>
                 <executions>
@@ -323,6 +337,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
Ensure that an Automatic-Module-Name entry is added to the final
MANIFEST.MF file in the produced jar. This will allow users of the
library to properly import and use it on the module path with a
stable, well-known name.

This commit does *not* change this library itself to be a modular jar,
nor does it incorporate any features that would break backwards
compatibility with JDK 7-8 clients.