### PR TITLE
Upgrade jnr-unixsocket dependency to v0.38.15 to fix CWE-416

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 /.settings/
 *.swp
 *.swo
+.vscode/
 
 # jenv
 .java-version

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
                  <dependency>
                     <groupId>com.github.jnr</groupId>
                     <artifactId>jnr-unixsocket</artifactId>
-                    <version>0.38.15</version>
+                    <version>0.38.17</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
-            <version>0.36</version>
+            <version>0.38.15</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Upgrading the `jnr-unixsocket` dependency to a version 0.38.15 so that it resolves security issue [CWE-416](https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422).

The branch has been tested using Apache Maven 3.8.5 on OpenJDK 1.8.0_312.
The command `mvn install` seems to complete successfully. 