### PR TITLE
Clear buffers before returning them to the pool

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -78,6 +78,7 @@ public class StatsDSender {
             try {
 
                 if (buffer != null) {
+                    buffer.clear();
                     pool.put(buffer);
                 }
 
@@ -91,7 +92,6 @@ public class StatsDSender {
                 buffer.flip();
                 final int sentBytes = clientChannel.write(buffer);
 
-                buffer.clear();
                 if (sizeOfBuffer != sentBytes) {
                     throw new IOException(
                             String.format("Could not send stat %s entirely to %s. Only sent %d out of %d bytes",


### PR DESCRIPTION
After an unsuccessful write, StatsDSender would not clear the buffer before returning it to the pool. This could cause the processor to get the buffer with lim<cap, possibly failing to write to the buffer and incorrectly submitting it to the sender again with pos=0 (which results in a no-op write, because after .flip() buffer would have pos=0,lim=0).

Fixes #198