### PR TITLE
Fix UnixSocketTest#resist_dsd_restart

### DIFF
--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -129,8 +129,9 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
         // Delete the socket file, client should throw an IOException
         lastException = new Exception();
         socketFile.delete();
+
+        client.gauge("mycount", 21);
         while(lastException.getMessage() == null) {
-            client.gauge("mycount", 20);
             Thread.sleep(10);
         }
         assertThat(lastException.getMessage(), containsString("No such file or directory"));


### PR DESCRIPTION
Avoid sending too many metrics to a closed socket, to avoid a race
condition with the lastException reset.

Occasionally, two metrics will be sent to the client after the server
socket was removed. First one triggers an exception and causes the
send loop to break. Test case then resets the lastException variable,
while the client is still running and has another message buffered. If
that is delivered before the server is started, it triggers another
exception and causes nullValue() check to fail and the end of the test
case.