### PR TITLE
Address message aggregation overhead

### DIFF
--- a/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
+++ b/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
@@ -1,8 +1,5 @@
 package com.timgroup.statsd;
 
-import java.util.Objects;
-
-
 public abstract class AlphaNumericMessage extends Message {
 
     protected final String value;
@@ -39,8 +36,8 @@ public abstract class AlphaNumericMessage extends Message {
     public int hashCode() {
 
         // cache it
-        if (this.hash == null) {
-            this.hash = super.hashCode() * HASH_MULTIPLIER + Objects.hash(this.value);
+        if (this.hash == Integer.MIN_VALUE) {
+            this.hash = super.hashCode() * HASH_MULTIPLIER + this.value.hashCode();
         }
 
         return this.hash;
@@ -55,10 +52,19 @@ public abstract class AlphaNumericMessage extends Message {
 
         if (object instanceof AlphaNumericMessage ) {
             AlphaNumericMessage msg = (AlphaNumericMessage)object;
-            return super.equals(msg) && (this.value.equals(msg.getValue()));
+            return this.value.equals(msg.getValue());
         }
 
         return false;
+    }
+
+    @Override
+    public int compareTo(Message message) {
+        int comparison = super.compareTo(message);
+        if (comparison == 0 && message instanceof AlphaNumericMessage) {
+            return value.compareTo(((AlphaNumericMessage) message).getValue());
+        }
+        return comparison;
     }
 }
 

--- a/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
+++ b/src/main/java/com/timgroup/statsd/AlphaNumericMessage.java
@@ -34,13 +34,7 @@ public abstract class AlphaNumericMessage extends Message {
 
     @Override
     public int hashCode() {
-
-        // cache it
-        if (this.hash == Integer.MIN_VALUE) {
-            this.hash = super.hashCode() * HASH_MULTIPLIER + this.value.hashCode();
-        }
-
-        return this.hash;
+        return super.hashCode() * HASH_MULTIPLIER + this.value.hashCode();
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/MapUtils.java
+++ b/src/main/java/com/timgroup/statsd/MapUtils.java
@@ -1,0 +1,52 @@
+package com.timgroup.statsd;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Map;
+
+/**
+ * MethodHandle based bridge for using JDK8+ functionality at JDK7 language level.
+ * Can be removed when support for JDK7 is dropped.
+ */
+public class MapUtils {
+
+    private static final MethodHandle MAP_PUT_IF_ABSENT = buildMapPutIfAbsent();
+    
+    /**
+     * Emulates {@code Map.putIfAbsent} semantics. Replace when baselining at JDK8+.
+     * @return the previous value associated with the message, or null if the value was not seen before
+     */
+    static Message putIfAbsent(Map<Message, Message> map, Message message) {
+        if (MAP_PUT_IF_ABSENT != null) {
+            try {
+                return (Message) (Object) MAP_PUT_IF_ABSENT.invokeExact(map, (Object) message, (Object) message);
+            } catch (Throwable ignore) {
+                return putIfAbsentFallback(map, message);
+            }
+        }
+        return putIfAbsentFallback(map, message);
+    }
+
+    /**
+     * Emulates {@code Map.putIfAbsent} semantics. Replace when baselining at JDK8+.
+     * @return the previous value associated with the message, or null if the value was not seen before
+     */
+    private static Message putIfAbsentFallback(Map<Message, Message> map, Message message) {
+        if (map.containsKey(message)) {
+            return map.get(message);
+        }
+        map.put(message, message);
+        return null;
+    }
+
+    private static MethodHandle buildMapPutIfAbsent() {
+        try {
+            return MethodHandles.publicLookup()
+                    .findVirtual(Map.class, "putIfAbsent",
+                            MethodType.methodType(Object.class, Object.class, Object.class));
+        } catch (Throwable ignore) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -144,6 +144,13 @@ public abstract class Message implements Comparable<Message> {
         return false;
     }
 
+    /**
+     * Note: this class has a natural ordering that is inconsistent with equals.
+     * Specifically, its natural order ignores tag-values. This is good enough
+     * for `HashMap` storage which does not require total order, but this precludes
+     * {@code Message} from being stored in a {@code SortedSet}.
+     * @param message the object to be compared.
+     */
     @Override
     public int compareTo(Message message) {
         int typeComparison = getType().compareTo(message.getType());

--- a/src/main/java/com/timgroup/statsd/StatsDAggregator.java
+++ b/src/main/java/com/timgroup/statsd/StatsDAggregator.java
@@ -2,6 +2,9 @@ package com.timgroup.statsd;
 
 import com.timgroup.statsd.Message;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -19,6 +22,8 @@ public class StatsDAggregator {
     public static int DEFAULT_SHARDS = 4;  // 4 partitions to reduce contention.
 
     protected final String AGGREGATOR_THREAD_NAME = "statsd-aggregator-thread";
+
+    private static final MethodHandle MAP_PUT_IF_ABSENT = buildMapPutIfAbsent();
     protected final Set<Message.Type> aggregateSet = new HashSet<>(
             Arrays.asList(Message.Type.COUNT, Message.Type.GAUGE, Message.Type.SET));
     protected final ArrayList<Map<Message, Message>> aggregateMetrics;
@@ -108,10 +113,8 @@ public class StatsDAggregator {
 
         synchronized (map) {
             // For now let's just put the message in the map
-            if (!map.containsKey(message)) {
-                map.put(message, message);
-            } else {
-                Message msg = map.get(message);
+            Message msg = putIfAbsent(map, message);
+            if (msg != null) {
                 msg.aggregate(message);
                 if (telemetry != null) {
                     telemetry.incrAggregatedContexts(1);
@@ -162,6 +165,43 @@ public class StatsDAggregator {
                     iter.remove();
                 }
             }
+        }
+    }
+
+    /**
+     * Emulates {@code Map.putIfAbsent} semantics. Replace when baselining at JDK8+.
+     * @return the previous value associated with the message, or null if the value was not seen before
+     */
+    private static Message putIfAbsent(Map<Message, Message> map, Message message) {
+        if (MAP_PUT_IF_ABSENT != null) {
+            try {
+                return (Message) (Object) MAP_PUT_IF_ABSENT.invokeExact(map, (Object) message, (Object) message);
+            } catch (Throwable ignore) {
+                return putIfAbsentFallback(map, message);
+            }
+        }
+        return putIfAbsentFallback(map, message);
+    }
+
+    /**
+     * Emulates {@code Map.putIfAbsent} semantics. Replace when baselining at JDK8+.
+     * @return the previous value associated with the message, or null if the value was not seen before
+     */
+    private static Message putIfAbsentFallback(Map<Message, Message> map, Message message) {
+        if (map.containsKey(message)) {
+            return map.get(message);
+        }
+        map.put(message, message);
+        return null;
+    }
+
+    private static MethodHandle buildMapPutIfAbsent() {
+        try {
+            return MethodHandles.publicLookup()
+                    .findVirtual(Map.class, "putIfAbsent",
+                            MethodType.methodType(Object.class, Object.class, Object.class));
+        } catch (Throwable ignore) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/timgroup/statsd/StatsDAggregator.java
+++ b/src/main/java/com/timgroup/statsd/StatsDAggregator.java
@@ -1,17 +1,13 @@
 package com.timgroup.statsd;
 
-import com.timgroup.statsd.Message;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -24,8 +20,8 @@ public class StatsDAggregator {
     protected final String AGGREGATOR_THREAD_NAME = "statsd-aggregator-thread";
 
     private static final MethodHandle MAP_PUT_IF_ABSENT = buildMapPutIfAbsent();
-    protected final Set<Message.Type> aggregateSet = new HashSet<>(
-            Arrays.asList(Message.Type.COUNT, Message.Type.GAUGE, Message.Type.SET));
+    protected static final Set<Message.Type> AGGREGATE_SET = EnumSet.of(Message.Type.COUNT, Message.Type.GAUGE,
+            Message.Type.SET);
     protected final ArrayList<Map<Message, Message>> aggregateMetrics;
 
     protected final int shardGranularity;
@@ -91,7 +87,7 @@ public class StatsDAggregator {
     }
 
     public boolean isTypeAggregate(Message.Type type) {
-        return aggregateSet.contains(type);
+        return AGGREGATE_SET.contains(type);
     }
 
     /**


### PR DESCRIPTION
We frequently see high overhead in message aggregation:

![Screenshot 2022-09-28 at 13 26 45](https://user-images.githubusercontent.com/16439049/192850725-2997ad96-37ec-407c-a4ba-9a68d69d5ea7.png)

This PR consists of 3 parts:

1. Use `Map.putIfAbsent` to avoid doubling the work done in `Map.get` then `Map.put` (note the almost identical stack traces next to eachother). This has to be done via `MethodHandle`s but this can be greatly simplified when JDK7 support is dropped.
2. Tweak `Message` for better hashing (note the `TreeMap` frames below `HashMap` which indicate hash collisions):
   * include the type in `hashCode` to avoid collisions in more cases
   * Use `Arrays.hashCode` instead of `Objects.hash` for the tags because the latter triggers an IDE warning for ambiguous varargs parameters
   * Remove the mutable `done` field from `equals` which can lead to memory leaks if the value changes after inserting a key into the map
   * short circuit `equals` when compared with `this`
   * Implement `Comparable` for better degradation when has collisions do occur
3. Change the aggregate types to `EnumMap` and make it static since it can be. The profile doesn't justify the change and I can drop the commit, but it's a generally worthwhile change.