### PR TITLE
feat: Support Dogstatsd 1.1 protocol for distributions

### DIFF
--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -92,6 +92,30 @@ public final class NoOpStatsDClient implements StatsDClient {
 
     @Override public void recordDistributionValue(String aspect, long value, double sampleRate, String... tags) { }
 
+    @Override
+    public void recordDistributionValue(String aspect, double[] values, String... tags) { }
+
+    @Override
+    public void recordDistributionValue(String aspect, double[] values, double sampleRate, String... tags) { }
+
+    @Override
+    public void recordDistributionValue(String aspect, long[] values, String... tags) { }
+
+    @Override
+    public void recordDistributionValue(String aspect, long[] values, double sampleRate, String... tags) { }
+
+    @Override
+    public void distribution(String aspect, double[] values, String... tags) { }
+
+    @Override
+    public void distribution(String aspect, double[] values, double sampleRate, String... tags) { }
+
+    @Override
+    public void distribution(String aspect, long[] values, String... tags) { }
+
+    @Override
+    public void distribution(String aspect, long[] values, double sampleRate, String... tags) { }
+
     @Override public void distribution(String aspect, double value, String... tags) { }
 
     @Override public void distribution(String aspect, double value, double sampleRate, String... tags) { }

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -651,6 +651,74 @@ public interface StatsDClient extends Closeable {
     void recordDistributionValue(String aspect, long value, double sampleRate, String... tags);
 
     /**
+     * Records values for the specified named distribution.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void recordDistributionValue(String aspect, double[] values, String... tags);
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param sampleRate
+     *     percentage of time metric to be sent
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void recordDistributionValue(String aspect, double[] values, double sampleRate, String... tags);
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void recordDistributionValue(String aspect, long[] values, String... tags);
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param sampleRate
+     *     percentage of time metric to be sent
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void recordDistributionValue(String aspect, long[] values, double sampleRate, String... tags);
+
+    /**
      * Convenience method equivalent to {@link #recordDistributionValue(String, double, String[])}.
      *
      * @param aspect
@@ -701,6 +769,58 @@ public interface StatsDClient extends Closeable {
      *     array of tags to be added to the data
      */
     void distribution(String aspect, long value, double sampleRate, String... tags);
+
+    /**
+     * Convenience method equivalent to {@link #recordDistributionValue(String, double[], String[])}.
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void distribution(String aspect, double[] values, String... tags);
+
+    /**
+     * Convenience method equivalent to {@link #recordDistributionValue(String, double[], double, String[])}.
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param sampleRate
+     *     percentage of time metric to be sent
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void distribution(String aspect, double[] values, double sampleRate, String... tags);
+
+    /**
+     * Convenience method equivalent to {@link #recordDistributionValue(String, long[], String[])}.
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void distribution(String aspect, long[] values, String... tags);
+
+    /**
+     * Convenience method equivalent to {@link #recordDistributionValue(String, long[], double, String[])}.
+     *
+     * @param aspect
+     *     the name of the distribution
+     * @param values
+     *     the values to be incorporated in the distribution
+     * @param sampleRate
+     *     percentage of time metric to be sent
+     * @param tags
+     *     array of tags to be added to the data
+     */
+    void distribution(String aspect, long[] values, double sampleRate, String... tags);
 
     /**
      * Records an event.

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -476,6 +476,63 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void sends_multivalued_distribution_to_statsd() throws Exception {
+
+        client.recordDistributionValue("mydistribution", new long[] { 423L, 234L });
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423:234|d")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_double_multivalued_distribution_to_statsd() throws Exception {
+
+
+        client.recordDistributionValue("mydistribution", new double[] { 0.423D, 0.234D });
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423:0.234|d")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_multivalued_distribution_to_statsd_with_tags() throws Exception {
+
+
+        client.recordDistributionValue("mydistribution", new long[] { 423L, 234L }, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423:234|d|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_multivalued_distribution_with_sample_rate_to_statsd_with_tags() throws Exception {
+
+        clientUnaggregated.recordDistributionValue("mydistribution", new long[] { 423L, 234L }, 1, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423:234|d|@1.000000|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_double_multivalued_distribution_to_statsd_with_tags() throws Exception {
+
+
+        client.recordDistributionValue("mydistribution", new double[] { 0.423D, 0.234D }, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423:0.234|d|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_double_multivalued_distribution_with_sample_rate_to_statsd_with_tags() throws Exception {
+
+        clientUnaggregated.recordDistributionValue("mydistribution", new double[] { 0.423D, 0.234D }, 1, "foo:bar", "baz");
+        server.waitForMessage("my.prefix");
+
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423:0.234|d|@1.000000|#baz,foo:bar")));
+    }
+
+    @Test(timeout = 5000L)
     public void sends_timer_to_statsd() throws Exception {
 
 


### PR DESCRIPTION
There is a new experimental Dogstatsd protocol (1.1) which supports sending multiple values in a single datagram.

This is supported since agent 7.25.0/6.25.0.

This evolution in the protocol allows clients to buffer histogram and distribution values and send them in fewer payload to the agent (providing a behavior close to client-side aggregation for those types).

This commit add support for this new protocol for distribution.

Fix #215