### PR TITLE
clear buffers before returning to pool in v2.X

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDSender.java
+++ b/src/main/java/com/timgroup/statsd/StatsDSender.java
@@ -81,6 +81,7 @@ public class StatsDSender {
             try {
 
                 if (buffer != null) {
+                    buffer.clear();
                     pool.put(buffer);
                 }
 
@@ -94,7 +95,6 @@ public class StatsDSender {
                 buffer.flip();
                 final int sentBytes = clientChannel.send(buffer, address);
 
-                buffer.clear();
                 if (sizeOfBuffer != sentBytes) {
                     throw new IOException(
                             String.format("Could not send stat %s entirely to %s. Only sent %d out of %d bytes",

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -16,6 +16,9 @@ import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.logging.Logger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1336,5 +1339,60 @@ public class NonBlockingStatsDClientTest {
                         entityID, bufferPoolSize, processorWorkers, senderWorkers, blocking);
             }
         }
+    }
+
+    @Test(timeout = 5000L)
+    public void failed_write_buffer() throws Exception {
+        final BlockingQueue sync = new ArrayBlockingQueue(1);
+        final IOException marker = new IOException();
+        NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder() {
+                @Override
+                public NonBlockingStatsDClient build() {
+                    this.originDetectionEnabled(false);
+                    this.bufferPoolSize(1);
+                    return new NonBlockingStatsDClient(resolve()) {
+                        @Override
+                        ClientChannel createByteChannel(Callable<SocketAddress> addressLookup, int timeout, int bufferSize) throws Exception {
+                            return new DatagramClientChannel(addressLookup.call()) {
+                                @Override
+                                public int write(ByteBuffer data) throws IOException {
+                                    try {
+                                        sync.put(new Object());
+                                    } catch (InterruptedException e) {
+                                    }
+                                    throw marker;
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+
+        final BlockingQueue errors = new LinkedBlockingQueue();
+        NonBlockingStatsDClient client = builder
+            .hostname("localhost")
+            .blocking(true)
+            .errorHandler(new StatsDClientErrorHandler() {
+                    @Override
+                    public void handle(Exception ex) {
+                        if (ex == marker) {
+                            return;
+                        }
+                        System.out.println(ex.toString());
+                        try {
+                            errors.put(ex);
+                        } catch (InterruptedException e) {
+                        }
+                    }
+
+                })
+            .build();
+
+        client.gauge("test", 1);
+        sync.take();
+        client.gauge("test", 1);
+        client.stop();
+
+        assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -16,9 +16,6 @@ import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.logging.Logger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1341,58 +1338,4 @@ public class NonBlockingStatsDClientTest {
         }
     }
 
-    @Test(timeout = 5000L)
-    public void failed_write_buffer() throws Exception {
-        final BlockingQueue sync = new ArrayBlockingQueue(1);
-        final IOException marker = new IOException();
-        NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder() {
-                @Override
-                public NonBlockingStatsDClient build() {
-                    this.originDetectionEnabled(false);
-                    this.bufferPoolSize(1);
-                    return new NonBlockingStatsDClient(resolve()) {
-                        @Override
-                        ClientChannel createByteChannel(Callable<SocketAddress> addressLookup, int timeout, int bufferSize) throws Exception {
-                            return new DatagramClientChannel(addressLookup.call()) {
-                                @Override
-                                public int write(ByteBuffer data) throws IOException {
-                                    try {
-                                        sync.put(new Object());
-                                    } catch (InterruptedException e) {
-                                    }
-                                    throw marker;
-                                }
-                            };
-                        }
-                    };
-                }
-            };
-
-        final BlockingQueue errors = new LinkedBlockingQueue();
-        NonBlockingStatsDClient client = builder
-            .hostname("localhost")
-            .blocking(true)
-            .errorHandler(new StatsDClientErrorHandler() {
-                    @Override
-                    public void handle(Exception ex) {
-                        if (ex == marker) {
-                            return;
-                        }
-                        System.out.println(ex.toString());
-                        try {
-                            errors.put(ex);
-                        } catch (InterruptedException e) {
-                        }
-                    }
-
-                })
-            .build();
-
-        client.gauge("test", 1);
-        sync.take();
-        client.gauge("test", 1);
-        client.stop();
-
-        assertEquals(0, errors.size());
-    }
 }


### PR DESCRIPTION
On version 2.13.0 of the client, we noticed truncation of tags when metrics are sent during restart of the datadog agent. This was narrowed down to the issue #198 which was resolved in #200. However, we are not in a position to upgrade the datadog agent to 4.2.0 at this time.

This solution backports clear buffers from #200 into v2.X branch. Ultimately, we would like to see a v2.13.1 release to resolve this.

cc @vickenty 

Cheers,
Andrew