### PR TITLE
Don't send partial messages when the utf8 encoder overflows

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDProcessor.java
@@ -116,8 +116,6 @@ public abstract class StatsDProcessor {
                         sendBuffer = bufferPool.borrow();
                     }
 
-                    sendBuffer.mark();
-
                     try {
                         writeBuilderToSendBuffer(sendBuffer);
                     } catch (BufferOverflowException boe) {
@@ -155,7 +153,9 @@ public abstract class StatsDProcessor {
                 buffer = CharBuffer.wrap(builder);
             }
 
+            sendBuffer.mark();
             if (utf8Encoder.encode(buffer, sendBuffer, true) == CoderResult.OVERFLOW) {
+                sendBuffer.reset();
                 throw new BufferOverflowException();
             }
         }


### PR DESCRIPTION
CharsetEncoder will encode messages up to full capacity of the destination buffer, and leave the data there even if the destination had insufficient capacity to encode the full payload. This can cause incomplete payloads to be sent to the agent, even though we threw an exception.