### PR TITLE
Updated readme to add working example for UDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ These are both configurable should you have other needs:
 ```java
 StatsDClient client = new NonBlockingStatsDClientBuilder()
     .hostname("/var/run/datadog/dsd.socket")
+    .port(0) // Necessary for unix socket
     .maxPacketSizeBytes(16384)  // 16kB maximum custom value
     .build();
 ```


### PR DESCRIPTION
The example here which demonstrates using a unix socket does not properly follow the guidance of using 0 as the port. The example as of the current revision does not work.