### PR TITLE
Updating CircleCI to use LTS JDKs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,24 +30,27 @@ jobs:
     <<: *default_steps
   openjdk8:
     docker: &jdk8
-      - image: circleci/openjdk:8u242
-    <<: *default_steps
-  openjdk9:
-    docker:
-      - image: circleci/openjdk:9.0.4-12
+      - image: cimg/openjdk:8.0
     <<: *default_steps
   openjdk11:
     docker:
-      - image: circleci/openjdk:11.0.2
+      - image: cimg/openjdk:11.0
     <<: *default_steps
   openjdk13:
     docker:
-      - image: circleci/openjdk:13.0.2-buster
+      - image: cimg/openjdk:13.0
     <<: *default_steps
-  openjdk14:
+  openjdk17:
     docker:
-      - image: circleci/openjdk:14.0.2-buster
+      - image: cimg/openjdk:17.0
     <<: *default_steps
+
+## Fails with "Source option 7 is no longer supported. Use 8 or later."
+#  openjdk21:
+#    docker:
+#      - image: cimg/openjdk:21.0
+#    <<: *default_steps
+
   windows-openjdk12:
     executor: win/default
     steps:
@@ -75,9 +78,10 @@ workflows:
     jobs:
       - openjdk7
       - openjdk8
-      - openjdk9
       - openjdk11
       - openjdk13
+      - openjdk17
+#      - openjdk21
       - windows-openjdk12
       - openjdk8-jnr-exclude
       - openjdk8-jnr-latest

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,27 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>new-jdks</id>
+            <activation>
+                <jdk>[16.0,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <configuration>
+                            <!-- Fix for "java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @75eeccf5" -->
+                            <argLine>
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -215,6 +236,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <!-- Can't use 3.4.1 as that needs Maven 3.2.5 -->
                 <version>3.0.0-M2</version>
                 <executions>
                     <execution>
@@ -225,7 +247,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.7.0-0,1.9.0-0),[9.0.0,13.0.14]</version>
+                                    <version>[1.7.0-0,1.9.0-0),[9.0,18.0-0)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -323,6 +345,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
This PR updates the CircleCI images to use the latest version (`circleci/openjdk` images have been [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)) and updates the JDKs being tested to use the latest LTS ones.

Currently can't use JDK 21 to build as it no longer supports source option 7.