### PR TITLE
[CONTINT-1132] Send in-<inode> using the cgroup controller when container-id cannot be retrieved

### DIFF
--- a/src/main/java/com/timgroup/statsd/CgroupReader.java
+++ b/src/main/java/com/timgroup/statsd/CgroupReader.java
@@ -1,9 +1,15 @@
 package com.timgroup.statsd;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,50 +20,89 @@ import java.util.regex.Pattern;
  */
 class CgroupReader {
     private static final Path CGROUP_PATH = Paths.get("/proc/self/cgroup");
+    /**
+     * DEFAULT_CGROUP_MOUNT_PATH is the default cgroup mount path.
+     **/
+    private static final Path DEFAULT_CGROUP_MOUNT_PATH = Paths.get("/sys/fs/cgroup");
+    /**
+     * CGROUP_NS_PATH is the path to the cgroup namespace file.
+     **/
+    private static final Path CGROUP_NS_PATH = Paths.get("/proc/self/ns/cgroup");
     private static final String CONTAINER_SOURCE = "[0-9a-f]{64}";
     private static final String TASK_SOURCE = "[0-9a-f]{32}-\\d+";
     private static final Pattern LINE_RE = Pattern.compile("^\\d+:[^:]*:(.+)$", Pattern.MULTILINE | Pattern.UNIX_LINES);
     private static final Pattern CONTAINER_RE = Pattern.compile(
             "(" + CONTAINER_SOURCE + "|" + TASK_SOURCE + ")(?:.scope)?$");
 
+    /**
+     * CGROUPV1_BASE_CONTROLLER is the controller used to identify the container-id
+     * in cgroup v1 (memory).
+     **/
+    private static final String CGROUPV1_BASE_CONTROLLER = "memory";
+    /**
+     * CGROUPV2_BASE_CONTROLLER is the controller used to identify the container-id
+     * in cgroup v2.
+     **/
+    private static final String CGROUPV2_BASE_CONTROLLER = "";
+    /**
+     * HOST_CGROUP_NAMESPACE_INODE is the inode of the host cgroup namespace.
+     **/
+    private static final long HOST_CGROUP_NAMESPACE_INODE = 0xEFFFFFFBL;
+
     private boolean readOnce = false;
+    /**
+     * containerID holds either the container ID or the cgroup controller inode.
+     **/
     public String containerID;
 
     /**
-     * Parses /proc/self/cgroup and returns the container ID if available.
+     * Returns the container ID if available or the cgroup controller inode.
      * 
-     * @throws IOException
-     *                     if /proc/self/cgroup is readable and still an I/O error
-     *                     occurs reading from the stream
+     * @throws IOException if /proc/self/cgroup is readable and still an I/O error
+     *                     occurs reading from the stream.
      */
     public String getContainerID() throws IOException {
         if (readOnce) {
             return containerID;
         }
 
-        containerID = read(CGROUP_PATH);
+        final String cgroupContent = read(CGROUP_PATH);
+        if (cgroupContent == null || cgroupContent.isEmpty()) {
+            return null;
+        }
+        containerID = parse(cgroupContent);
+        /*
+         * If the container ID is not available it means that the application is either
+         * not running in a container or running is private cgroup namespace, we
+         * fallback to the cgroup controller inode. The agent (7.51+) will use it to get
+         * the container ID.
+         * 
+         */
+        if ((containerID == null || containerID.equals("")) && !isHostCgroupNamespace(CGROUP_NS_PATH)) {
+            containerID = getCgroupInode(DEFAULT_CGROUP_MOUNT_PATH, cgroupContent);
+        }
         return containerID;
     }
 
+    /**
+     * Parses `path` (=/proc/self/cgroup) and returns the container ID if available.
+     * 
+     * @throws IOException if /proc/self/cgroup is readable and still an I/O error
+     *                     occurs reading from the stream.
+     */
     private String read(Path path) throws IOException {
         readOnce = true;
         if (!Files.isReadable(path)) {
             return null;
         }
 
-        final String content = new String(Files.readAllBytes(path));
-        if (content.isEmpty()) {
-            return null;
-        }
-
-        return parse(content);
+        return new String(Files.readAllBytes(path));
     }
 
     /**
      * Parses a Cgroup file content and returns the corresponding container ID.
      * 
-     * @param cgroupsContent
-     *                       Cgroup file content
+     * @param cgroupsContent Cgroup file content
      */
     public static String parse(final String cgroupsContent) {
         final Matcher lines = LINE_RE.matcher(cgroupsContent);
@@ -70,5 +115,85 @@ class CgroupReader {
         }
 
         return null;
+    }
+
+    /**
+     * Returns true if the host cgroup namespace is used.
+     * It looks at the inode of `/proc/self/ns/cgroup` and compares it to
+     * HOST_CGROUP_NAMESPACE_INODE.
+     * 
+     * @param path Path to the cgroup namespace file.
+     */
+    private static boolean isHostCgroupNamespace(final Path path) {
+        long hostCgroupInode = inodeForPath(path);
+        return hostCgroupInode == HOST_CGROUP_NAMESPACE_INODE;
+    }
+
+    /**
+     * Returns the inode for the given path.
+     * 
+     * @param path Path to the cgroup namespace file.
+     */
+    private static long inodeForPath(final Path path) {
+        try {
+            long inode = (long) Files.getAttribute(path, "unix:ino");
+            return inode;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Returns the cgroup controller inode for the given cgroup mount path and
+     * procSelfCgroupPath.
+     * 
+     * @param cgroupMountPath Path to the cgroup mount point.
+     * @param cgroupContent   String content of the cgroup file.
+     */
+    public static String getCgroupInode(final Path cgroupMountPath, final String cgroupContent) throws IOException {
+        Map<String, String> cgroupControllersPaths = parseCgroupNodePath(cgroupContent);
+        if (cgroupControllersPaths == null) {
+            return null;
+        }
+
+        // Retrieve the cgroup inode from /sys/fs/cgroup+controller+cgroupNodePath
+        List<String> controllers = Arrays.asList(CGROUPV1_BASE_CONTROLLER, CGROUPV2_BASE_CONTROLLER);
+        for (String controller : controllers) {
+            String cgroupNodePath = cgroupControllersPaths.get(controller);
+            if (cgroupNodePath == null) {
+                continue;
+            }
+            Path path = Paths.get(cgroupMountPath.toString(), controller, cgroupNodePath);
+            long inode = inodeForPath(path);
+            if (inode > 2) {
+                return "in-" + inode;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a map of cgroup controllers and their corresponding cgroup path.
+     * 
+     * @param cgroupContent Cgroup file content.
+     */
+    public static Map<String, String> parseCgroupNodePath(final String cgroupContent) throws IOException {
+        Map<String, String> res = new HashMap<>();
+        BufferedReader br = new BufferedReader(new StringReader(cgroupContent));
+
+        String line;
+        while ((line = br.readLine()) != null) {
+            String[] tokens = line.split(":");
+            if (tokens.length != 3) {
+                continue;
+            }
+            if (CGROUPV1_BASE_CONTROLLER.equals(tokens[1]) || tokens[1].isEmpty()) {
+                res.put(tokens[1], tokens[2]);
+            }
+        }
+
+        br.close();
+        return res;
     }
 }

--- a/src/main/java/com/timgroup/statsd/CgroupReader.java
+++ b/src/main/java/com/timgroup/statsd/CgroupReader.java
@@ -14,8 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A reader class that retrieves the current container ID parsed from a the
- * cgroup file.
+ * A reader class that retrieves the current container ID or the cgroup controller
+ * inode parsed from the cgroup file.
  *
  */
 class CgroupReader {

--- a/src/main/java/com/timgroup/statsd/CgroupReader.java
+++ b/src/main/java/com/timgroup/statsd/CgroupReader.java
@@ -8,7 +8,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A reader class that retrieves the current container ID parsed from a the cgroup file.
+ * A reader class that retrieves the current container ID parsed from a the
+ * cgroup file.
  *
  */
 class CgroupReader {
@@ -16,8 +17,7 @@ class CgroupReader {
     private static final String CONTAINER_SOURCE = "[0-9a-f]{64}";
     private static final String TASK_SOURCE = "[0-9a-f]{32}-\\d+";
     private static final Pattern LINE_RE = Pattern.compile("^\\d+:[^:]*:(.+)$", Pattern.MULTILINE | Pattern.UNIX_LINES);
-    private static final Pattern CONTAINER_RE =
-        Pattern.compile(
+    private static final Pattern CONTAINER_RE = Pattern.compile(
             "(" + CONTAINER_SOURCE + "|" + TASK_SOURCE + ")(?:.scope)?$");
 
     private boolean readOnce = false;
@@ -27,7 +27,8 @@ class CgroupReader {
      * Parses /proc/self/cgroup and returns the container ID if available.
      * 
      * @throws IOException
-     *     if /proc/self/cgroup is readable and still an I/O error occurs reading from the stream
+     *                     if /proc/self/cgroup is readable and still an I/O error
+     *                     occurs reading from the stream
      */
     public String getContainerID() throws IOException {
         if (readOnce) {
@@ -56,7 +57,7 @@ class CgroupReader {
      * Parses a Cgroup file content and returns the corresponding container ID.
      * 
      * @param cgroupsContent
-     *     Cgroup file content
+     *                       Cgroup file content
      */
     public static String parse(final String cgroupsContent) {
         final Matcher lines = LINE_RE.matcher(cgroupsContent);

--- a/src/test/java/com/timgroup/statsd/CgroupReaderTest.java
+++ b/src/test/java/com/timgroup/statsd/CgroupReaderTest.java
@@ -1,8 +1,17 @@
 package com.timgroup.statsd;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -12,112 +21,184 @@ public class CgroupReaderTest {
     public void containerID_parse() throws Exception {
         // Docker
         String docker = new StringBuilder()
-        .append("13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-        .append("1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860")
-        .toString();
+                .append("13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+                .append("1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860")
+                .toString();
 
-        assertThat(CgroupReader.parse(docker), equalTo("3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"));
+        assertThat(CgroupReader.parse(docker),
+                equalTo("3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"));
 
         // Kubernetes
         String kubernetes = new StringBuilder()
-        .append("11:perf_event:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("10:pids:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("9:memory:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("8:cpu,cpuacct:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("7:blkio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("6:cpuset:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("5:devices:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("4:freezer:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append(" 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-        .append("1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1")
-        .toString();
+                .append("11:perf_event:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("10:pids:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("9:memory:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("8:cpu,cpuacct:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("7:blkio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("6:cpuset:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("5:devices:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("4:freezer:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append(" 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+                .append("1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1")
+                .toString();
 
-        assertThat(CgroupReader.parse(kubernetes), equalTo("3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"));
+        assertThat(CgroupReader.parse(kubernetes),
+                equalTo("3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"));
 
         // ECS EC2
         String ecs = new StringBuilder()
-        .append("9:perf_event:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("8:memory:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("7:hugetlb:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("6:freezer:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("5:devices:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("4:cpuset:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("3:cpuacct:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("2:cpu:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-        .append("1:blkio:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce")
-        .toString();
+                .append("9:perf_event:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("8:memory:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("7:hugetlb:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("6:freezer:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("5:devices:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("4:cpuset:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("3:cpuacct:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("2:cpu:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+                .append("1:blkio:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce")
+                .toString();
 
-        assertThat(CgroupReader.parse(ecs), equalTo("38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce"));
+        assertThat(CgroupReader.parse(ecs),
+                equalTo("38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce"));
 
         // ECS Fargate
         String ecsFargate = new StringBuilder()
-        .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .append("1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-        .toString();
+                .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .append("1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+                .toString();
 
-        assertThat(CgroupReader.parse(ecsFargate), equalTo("432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da"));
+        assertThat(CgroupReader.parse(ecsFargate),
+                equalTo("432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da"));
 
         // ECS Fargate >= 1.4.0
         String ecsFargate14 = new StringBuilder()
-        .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .append("1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-        .toString();
+                .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .append("1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+                .toString();
 
         assertThat(CgroupReader.parse(ecsFargate14), equalTo("34dc0b5e626f2c5c4c5170e34b10e765-1234567890"));
 
         // Linux non-containerized
         String nonContainerized = new StringBuilder()
-        .append("11:blkio:/user.slice/user-0.slice/session-14.scope\n")
-        .append("10:memory:/user.slice/user-0.slice/session-14.scope\n")
-        .append("9:hugetlb:/\n")
-        .append("8:cpuset:/\n")
-        .append("7:pids:/user.slice/user-0.slice/session-14.scope\n")
-        .append("6:freezer:/\n")
-        .append("5:net_cls,net_prio:/\n")
-        .append("4:perf_event:/\n")
-        .append("3:cpu,cpuacct:/user.slice/user-0.slice/session-14.scope\n")
-        .append("2:devices:/user.slice/user-0.slice/session-14.scope\n")
-        .append("1:name=systemd:/user.slice/user-0.slice/session-14.scope\n")
-        .toString();
+                .append("11:blkio:/user.slice/user-0.slice/session-14.scope\n")
+                .append("10:memory:/user.slice/user-0.slice/session-14.scope\n")
+                .append("9:hugetlb:/\n")
+                .append("8:cpuset:/\n")
+                .append("7:pids:/user.slice/user-0.slice/session-14.scope\n")
+                .append("6:freezer:/\n")
+                .append("5:net_cls,net_prio:/\n")
+                .append("4:perf_event:/\n")
+                .append("3:cpu,cpuacct:/user.slice/user-0.slice/session-14.scope\n")
+                .append("2:devices:/user.slice/user-0.slice/session-14.scope\n")
+                .append("1:name=systemd:/user.slice/user-0.slice/session-14.scope\n")
+                .toString();
 
         assertNull(CgroupReader.parse(nonContainerized));
 
         // Linux 4.4
         String linux44 = new StringBuilder()
-        .append("11:pids:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
-        .append("1:name=systemd:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
-        .toString();
+                .append("11:pids:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
+                .append("1:name=systemd:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
+                .toString();
 
-        assertThat(CgroupReader.parse(linux44), equalTo("cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411"));
+        assertThat(CgroupReader.parse(linux44),
+                equalTo("cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411"));
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void assumeNotWindows() {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+    }
+
+    @Test
+    public void testWithExistingCgroupV1Inode() throws IOException {
+
+        folder.create();
+        Path cgroupMountPath = folder.newFolder("sys", "fs", "cgroup").toPath();
+        Path controllerDir = cgroupMountPath.resolve("memory");
+        Path cgroupPath = controllerDir.resolve("docker");
+        Path nodePath = cgroupPath.resolve("3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860");
+        Files.createDirectories(nodePath);
+
+        long inode = (long) Files.getAttribute(nodePath, "unix:ino");
+
+        String cgroupContent = "myfile\5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n";
+        String inodeResult = CgroupReader.getCgroupInode(cgroupMountPath, cgroupContent);
+
+        assertEquals("in-" + inode, inodeResult);
+    }
+
+    @Test
+    public void testWithExistingCgroupV2Inode() throws IOException {
+
+        folder.create();
+        Path cgroupMountPath = folder.newFolder("sys", "fs", "cgroup").toPath();
+        Files.createDirectories(cgroupMountPath);
+
+        long inodeNumber = (long) Files.getAttribute(cgroupMountPath, "unix:ino");
+        String cgroupContent = "0::/\n";
+        String inodeResult = CgroupReader.getCgroupInode(cgroupMountPath, cgroupContent);
+
+        assertEquals("in-" + inodeNumber, inodeResult);
+    }
+
+    @Test
+    public void testWithNonExistentCgroupNodePath() throws IOException {
+
+        folder.create();
+        Path cgroupMountPath = folder.newFolder("sys", "fs", "cgroup").toPath();
+
+        String cgroupContent = "memory:/nonexistentpath\n";
+        String inodeResult = CgroupReader.getCgroupInode(cgroupMountPath,
+                cgroupContent);
+
+        assertNull(inodeResult);
+
+    }
+
+    @Test
+    public void testWithEmptyCgroupContent() throws IOException {
+
+        folder.create();
+        Path cgroupMountPath = folder.newFolder("sys", "fs", "cgroup").toPath();
+
+        String cgroupContent = "";
+        String inodeResult = CgroupReader.getCgroupInode(cgroupMountPath,
+                cgroupContent);
+
+        assertNull(inodeResult);
     }
 }

--- a/src/test/java/com/timgroup/statsd/CgroupReaderTest.java
+++ b/src/test/java/com/timgroup/statsd/CgroupReaderTest.java
@@ -21,118 +21,113 @@ public class CgroupReaderTest {
     public void containerID_parse() throws Exception {
         // Docker
         String docker = new StringBuilder()
-                .append("13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
-                .append("1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860")
-                .toString();
+        .append("13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n")
+        .append("1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860")
+        .toString();
 
-        assertThat(CgroupReader.parse(docker),
-                equalTo("3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"));
+        assertThat(CgroupReader.parse(docker), equalTo("3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"));
 
         // Kubernetes
         String kubernetes = new StringBuilder()
-                .append("11:perf_event:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("10:pids:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("9:memory:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("8:cpu,cpuacct:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("7:blkio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("6:cpuset:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("5:devices:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("4:freezer:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append(" 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
-                .append("1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1")
-                .toString();
+        .append("11:perf_event:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("10:pids:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("9:memory:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("8:cpu,cpuacct:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("7:blkio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("6:cpuset:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("5:devices:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("4:freezer:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append(" 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n")
+        .append("1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1")
+        .toString();
 
-        assertThat(CgroupReader.parse(kubernetes),
-                equalTo("3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"));
+        assertThat(CgroupReader.parse(kubernetes), equalTo("3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"));
 
         // ECS EC2
         String ecs = new StringBuilder()
-                .append("9:perf_event:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("8:memory:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("7:hugetlb:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("6:freezer:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("5:devices:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("4:cpuset:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("3:cpuacct:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("2:cpu:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
-                .append("1:blkio:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce")
-                .toString();
+        .append("9:perf_event:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("8:memory:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("7:hugetlb:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("6:freezer:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("5:devices:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("4:cpuset:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("3:cpuacct:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("2:cpu:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce\n")
+        .append("1:blkio:/ecs/name-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce")
+        .toString();
 
-        assertThat(CgroupReader.parse(ecs),
-                equalTo("38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce"));
+        assertThat(CgroupReader.parse(ecs), equalTo("38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce"));
 
         // ECS Fargate
         String ecsFargate = new StringBuilder()
-                .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .append("1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
-                .toString();
+        .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .append("1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da\n")
+        .toString();
 
-        assertThat(CgroupReader.parse(ecsFargate),
-                equalTo("432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da"));
+        assertThat(CgroupReader.parse(ecsFargate), equalTo("432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da"));
 
         // ECS Fargate >= 1.4.0
         String ecsFargate14 = new StringBuilder()
-                .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .append("1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
-                .toString();
+        .append("11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .append("1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890\n")
+        .toString();
 
         assertThat(CgroupReader.parse(ecsFargate14), equalTo("34dc0b5e626f2c5c4c5170e34b10e765-1234567890"));
 
         // Linux non-containerized
         String nonContainerized = new StringBuilder()
-                .append("11:blkio:/user.slice/user-0.slice/session-14.scope\n")
-                .append("10:memory:/user.slice/user-0.slice/session-14.scope\n")
-                .append("9:hugetlb:/\n")
-                .append("8:cpuset:/\n")
-                .append("7:pids:/user.slice/user-0.slice/session-14.scope\n")
-                .append("6:freezer:/\n")
-                .append("5:net_cls,net_prio:/\n")
-                .append("4:perf_event:/\n")
-                .append("3:cpu,cpuacct:/user.slice/user-0.slice/session-14.scope\n")
-                .append("2:devices:/user.slice/user-0.slice/session-14.scope\n")
-                .append("1:name=systemd:/user.slice/user-0.slice/session-14.scope\n")
-                .toString();
+        .append("11:blkio:/user.slice/user-0.slice/session-14.scope\n")
+        .append("10:memory:/user.slice/user-0.slice/session-14.scope\n")
+        .append("9:hugetlb:/\n")
+        .append("8:cpuset:/\n")
+        .append("7:pids:/user.slice/user-0.slice/session-14.scope\n")
+        .append("6:freezer:/\n")
+        .append("5:net_cls,net_prio:/\n")
+        .append("4:perf_event:/\n")
+        .append("3:cpu,cpuacct:/user.slice/user-0.slice/session-14.scope\n")
+        .append("2:devices:/user.slice/user-0.slice/session-14.scope\n")
+        .append("1:name=systemd:/user.slice/user-0.slice/session-14.scope\n")
+        .toString();
 
         assertNull(CgroupReader.parse(nonContainerized));
 
         // Linux 4.4
         String linux44 = new StringBuilder()
-                .append("11:pids:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
-                .append("1:name=systemd:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
-                .toString();
+        .append("11:pids:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
+        .append("1:name=systemd:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope\n")
+        .toString();
 
-        assertThat(CgroupReader.parse(linux44),
-                equalTo("cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411"));
+        assertThat(CgroupReader.parse(linux44), equalTo("cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411"));
     }
 
     @Rule


### PR DESCRIPTION
Implementation of https://github.com/DataDog/datadog-go/pull/291 but in Java

This Pull Request implements the support of Origin Detection when the container-id is unavailable from inside the application container only with cgroupv2.

It first retrieves the cgroup node path by parsing proc/self/cgroup which is formatted differently depending on the cgroup version. See https://man7.org/linux/man-pages/man7/cgroups.7.html.

The format is a list of hierarchy-ID:controller-list:cgroup-path  similar to:

0::<path>
1:name=systemd:... // only in cgroupv1
Once the path is retrieved, we retrieve the inode of /sys/fs/cgroup + <controller> + <path> where <path> is the path retrieved previously.

I am not sure how to create a dummy app that uses this library.

## Test

- Set up a cgroupv2 environment. A kind cluster should be enough.
- Deploy the agent 7.51.0+ with origin detection and dogstatsd enabled. Using helm:
```
  dogstatsd:
    port: 8125
    originDetection: true
    useHostPort: true
    useHostPID: true
    tagCardinality: high
```
- Note that you will also need the env var:
```
    - name: "DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT"
      value: "true"
```
- Deploy a dummy app. I already made one with and without this change:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-java-dsd-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: my-java-dsd-app
  template:
    metadata:
      labels:
        app: my-java-dsd-app
        admission.datadoghq.com/enabled: "false"
    spec:
      containers:
      - name: my-java-dsd-app
        image: docker.io/alidatadog/dummy-java-dsd-app:with-inode@sha256:a62e653e3c8e493611ba5841d3af94921edef0670776d0555fed9eecc2b50341 # use the tag without-inode for comparison
        imagePullPolicy: Always
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```
- Verify that `dummy.metric` is correctly tagged with container-id when it wasn't before.
If you are curious about the dummy app, I pushed it here https://github.com/AliDatadog/dummy-dsd-java-app.