### PR TITLE
feat: Add an API to send multiple samples at once

### DIFF
--- a/src/main/java/com/timgroup/statsd/DirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/DirectStatsDClient.java
@@ -1,0 +1,46 @@
+package com.timgroup.statsd;
+
+/**
+ * DirectStatsDClient is an experimental extension of {@link StatsDClient} that allows for direct access to some
+ * dogstatsd features.
+ *
+ * <p>It is not recommended to use this client in production. This client might allow you to take advantage of
+ * new features in the agent before they are released, but it might also break your application.
+ */
+public interface DirectStatsDClient extends StatsDClient {
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>The method doesn't take care of breaking down the values array if it is too large. It's up to the caller to
+     * make sure the size is kept reasonable.</p>
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect     the name of the distribution
+     * @param values     the values to be incorporated in the distribution
+     * @param sampleRate percentage of time metric to be sent
+     * @param tags       array of tags to be added to the data
+     */
+    void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags);
+
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>The method doesn't take care of breaking down the values array if it is too large. It's up to the caller to
+     * make sure the size is kept reasonable.</p>
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect     the name of the distribution
+     * @param values     the values to be incorporated in the distribution
+     * @param sampleRate percentage of time metric to be sent
+     * @param tags       array of tags to be added to the data
+     */
+    void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags);
+}

--- a/src/main/java/com/timgroup/statsd/NoOpDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpDirectStatsDClient.java
@@ -1,0 +1,11 @@
+package com.timgroup.statsd;
+
+/**
+ * A No-Op {@link NonBlockingDirectStatsDClient}, which can be substituted in when metrics are not
+ * required.
+ */
+public final class NoOpDirectStatsDClient extends NoOpStatsDClient implements DirectStatsDClient {
+    @Override public void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags) { }
+
+    @Override public void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags) { }
+}

--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -7,7 +7,10 @@ package com.timgroup.statsd;
  * @author Tom Denley
  *
  */
-public final class NoOpStatsDClient implements StatsDClient {
+public class NoOpStatsDClient implements StatsDClient {
+
+    NoOpStatsDClient() {}
+
     @Override public void stop() { }
 
     @Override public void close() { }

--- a/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
@@ -1,0 +1,103 @@
+package com.timgroup.statsd;
+
+final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implements DirectStatsDClient {
+
+    public NonBlockingDirectStatsDClient(final NonBlockingStatsDClientBuilder builder) throws StatsDClientException {
+        super(builder.prefix, builder.queueSize, builder.constantTags, builder.errorHandler,
+                builder.addressLookup, builder.telemetryAddressLookup, builder.timeout,
+                builder.socketBufferSize, builder.maxPacketSizeBytes, builder.entityID,
+                builder.bufferPoolSize, builder.processorWorkers, builder.senderWorkers,
+                builder.blocking, builder.enableTelemetry, builder.telemetryFlushInterval,
+                (builder.enableAggregation ? builder.aggregationFlushInterval : 0),
+                builder.aggregationShards, builder.threadFactory, builder.containerID,
+                builder.originDetectionEnabled);
+    }
+
+    @Override
+    public void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags) {
+        if ((Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) && values != null && values.length > 0) {
+            sendMetric(new DoublesStatsDMessage(aspect, Message.Type.DISTRIBUTION, values, sampleRate, 0, tags));
+        }
+    }
+
+    @Override
+    public void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags) {
+        if ((Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) && values != null && values.length > 0) {
+            sendMetric(new LongsStatsDMessage(aspect, Message.Type.DISTRIBUTION, values, sampleRate, 0, tags));
+        }
+    }
+
+    abstract class MultiValuedStatsDMessage extends Message {
+        private final double sampleRate; // NaN for none
+        private final long timestamp; // zero for none
+
+        MultiValuedStatsDMessage(String aspect, Message.Type type, String[] tags, double sampleRate, long timestamp) {
+            super(aspect, type, tags);
+            this.sampleRate = sampleRate;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public final boolean canAggregate() {
+            return false;
+        }
+
+        @Override
+        public final void aggregate(Message message) {
+        }
+
+        @Override
+        public final void writeTo(StringBuilder builder, String containerID) {
+            builder.append(prefix).append(aspect);
+            writeValuesTo(builder);
+            builder.append('|').append(type);
+            if (!Double.isNaN(sampleRate)) {
+                builder.append('|').append('@').append(format(SAMPLE_RATE_FORMATTER, sampleRate));
+            }
+            if (timestamp != 0) {
+                builder.append("|T").append(timestamp);
+            }
+            tagString(tags, builder);
+            if (containerID != null && !containerID.isEmpty()) {
+                builder.append("|c:").append(containerID);
+            }
+
+            builder.append('\n');
+        }
+
+        protected abstract void writeValuesTo(StringBuilder builder);
+    }
+
+    final class LongsStatsDMessage extends MultiValuedStatsDMessage {
+        private final long[] values;
+
+        LongsStatsDMessage(String aspect, Message.Type type, long[] values, double sampleRate, long timestamp, String[] tags) {
+            super(aspect, type, tags, sampleRate, timestamp);
+            this.values = values;
+        }
+
+        @Override
+        protected void writeValuesTo(StringBuilder builder) {
+            for (long value : values) {
+                builder.append(':').append(value);
+            }
+        }
+    }
+
+    final class DoublesStatsDMessage extends MultiValuedStatsDMessage {
+        private final double[] values;
+
+        DoublesStatsDMessage(String aspect, Message.Type type, double[] values, double sampleRate, long timestamp,
+                             String[] tags) {
+            super(aspect, type, tags, sampleRate, timestamp);
+            this.values = values;
+        }
+
+        @Override
+        protected void writeValuesTo(StringBuilder builder) {
+            for (double value : values) {
+                builder.append(':').append(value);
+            }
+        }
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -18,8 +18,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
@@ -160,7 +158,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         return formatter.get().format(value);
     }
 
-    private final String prefix;
+    final String prefix;
     private final ClientChannel clientChannel;
     private final ClientChannel telemetryClientChannel;
     private final StatsDClientErrorHandler handler;
@@ -243,7 +241,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * @throws StatsDClientException
      *     if the client could not be started
      */
-    private NonBlockingStatsDClient(final String prefix, final int queueSize, final String[] constantTags,
+    NonBlockingStatsDClient(final String prefix, final int queueSize, final String[] constantTags,
             final StatsDClientErrorHandler errorHandler, final Callable<SocketAddress> addressLookup,
             final Callable<SocketAddress> telemetryAddressLookup, final int timeout, final int bufferSize,
             final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
@@ -532,7 +530,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
 
-    private boolean sendMetric(final Message message) {
+    boolean sendMetric(final Message message) {
         return send(message);
     }
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -194,6 +194,18 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
     }
 
     /**
+     * {@link DirectStatsDClient} factory method.
+     * 
+     * <p>It is an experimental extension of {@link StatsDClient} that allows for direct access to some dogstatsd features.
+     * It is not recommended to use this client in production.
+     * @return the built DirectStatsDClient.
+     * @see DirectStatsDClient
+     */
+    public DirectStatsDClient buildDirectStatsDClient() throws StatsDClientException {
+        return new NonBlockingDirectStatsDClient(resolve());
+    }
+
+    /**
      * Creates a copy of this builder with any implicit elements resolved.
      * @return the resolved copy of the builder.
      */
@@ -212,7 +224,7 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
         if (lookup == null) {
             String namedPipeFromEnv = System.getenv(NonBlockingStatsDClient.DD_NAMED_PIPE_ENV_VAR);
             String resolvedNamedPipe = namedPipe == null ? namedPipeFromEnv : namedPipe;
-            
+
             if (resolvedNamedPipe == null) {
                 lookup = staticStatsDAddressResolution(hostname, port);
             } else {


### PR DESCRIPTION
recordDistributionValues is similar to recordDistributionValue but it lets the client sends multiple samples in one message using dogstatsd 1.1 protocol.

Because this is a shift compared to how other methods are behaving, these methods are provided only in DirectStatsDClient which provides direct access to some low level dogstatsd protocol features.

This is recommended in high performance cases were the overhead of the statsd library might be significant and the sampling is already done by the client.

Port of https://github.com/DataDog/datadog-go/pull/296.