### PR TITLE
feat: Add an API to send multiple samples at once

### DIFF
--- a/src/main/java/com/timgroup/statsd/DirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/DirectStatsDClient.java
@@ -1,0 +1,46 @@
+package com.timgroup.statsd;
+
+/**
+ * DirectStatsDClient is an experimental extension of {@link StatsDClient} that allows for direct access to some
+ * dogstatsd features.
+ *
+ * <p>It is not recommended to use this client in production. This client might allow you to take advantage of
+ * new features in the agent before they are released, but it might also break your application.
+ */
+public interface DirectStatsDClient extends StatsDClient {
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>The method doesn't take care of breaking down the values array if it is too large. It's up to the caller to
+     * make sure the size is kept reasonable.</p>
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect     the name of the distribution
+     * @param values     the values to be incorporated in the distribution
+     * @param sampleRate percentage of time metric to be sent
+     * @param tags       array of tags to be added to the data
+     */
+    void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags);
+
+
+    /**
+     * Records values for the specified named distribution.
+     *
+     * <p>The method doesn't take care of breaking down the values array if it is too large. It's up to the caller to
+     * make sure the size is kept reasonable.</p>
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param aspect     the name of the distribution
+     * @param values     the values to be incorporated in the distribution
+     * @param sampleRate percentage of time metric to be sent
+     * @param tags       array of tags to be added to the data
+     */
+    void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags);
+}

--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -54,10 +54,13 @@ public abstract class Message implements Comparable<Message> {
      * Write this message to the provided {@link StringBuilder}. Will
      * be called from the sender threads.
      *
-     * @param builder
-     *     StringBuilder the text representation will be written to.
+     * @param builder     StringBuilder the text representation will be written to.
+     * @param capacity    The capacity of the send buffer.
+     * @param containerID The container ID to be appended to the message.
+     * @return boolean indicating whether the message was partially written to the builder.
+     *     If true, the method will be called again with the same arguments to continue writing.
      */
-    abstract void writeTo(StringBuilder builder, String containerID);
+    abstract boolean writeTo(StringBuilder builder, int capacity, String containerID);
 
     /**
      * Aggregate message.

--- a/src/main/java/com/timgroup/statsd/NoOpDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpDirectStatsDClient.java
@@ -1,0 +1,11 @@
+package com.timgroup.statsd;
+
+/**
+ * A No-Op {@link NonBlockingDirectStatsDClient}, which can be substituted in when metrics are not
+ * required.
+ */
+public final class NoOpDirectStatsDClient extends NoOpStatsDClient implements DirectStatsDClient {
+    @Override public void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags) { }
+
+    @Override public void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags) { }
+}

--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -7,7 +7,10 @@ package com.timgroup.statsd;
  * @author Tom Denley
  *
  */
-public final class NoOpStatsDClient implements StatsDClient {
+public class NoOpStatsDClient implements StatsDClient {
+
+    NoOpStatsDClient() {}
+
     @Override public void stop() { }
 
     @Override public void close() { }

--- a/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
@@ -1,5 +1,7 @@
 package com.timgroup.statsd;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implements DirectStatsDClient {
 
     public NonBlockingDirectStatsDClient(final NonBlockingStatsDClientBuilder builder) throws StatsDClientException {
@@ -61,10 +63,11 @@ final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implem
 
         private int metadataSize(StringBuilder builder, String containerID) {
             if (metadataSize == -1) {
-                int previousLength = builder.length();
+                final int previousLength = builder.length();
+                final int previousEncodedLength = builder.toString().getBytes(UTF_8).length;
                 writeHeadMetadata(builder);
                 writeTailMetadata(builder, containerID);
-                metadataSize = builder.length() - previousLength;
+                metadataSize = builder.toString().getBytes(UTF_8).length - previousEncodedLength;
                 builder.setLength(previousLength);
             }
             return metadataSize;

--- a/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
@@ -1,0 +1,96 @@
+package com.timgroup.statsd;
+
+final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implements DirectStatsDClient {
+
+    public NonBlockingDirectStatsDClient(final NonBlockingStatsDClientBuilder builder) throws StatsDClientException {
+        super(builder);
+    }
+
+    @Override
+    public void recordDistributionValues(String aspect, double[] values, double sampleRate, String... tags) {
+        if ((Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) && values != null && values.length > 0) {
+            sendMetric(new DoublesStatsDMessage(aspect, Message.Type.DISTRIBUTION, values, sampleRate, 0, tags));
+        }
+    }
+
+    @Override
+    public void recordDistributionValues(String aspect, long[] values, double sampleRate, String... tags) {
+        if ((Double.isNaN(sampleRate) || !isInvalidSample(sampleRate)) && values != null && values.length > 0) {
+            sendMetric(new LongsStatsDMessage(aspect, Message.Type.DISTRIBUTION, values, sampleRate, 0, tags));
+        }
+    }
+
+    abstract class MultiValuedStatsDMessage extends Message {
+        private final double sampleRate; // NaN for none
+        private final long timestamp; // zero for none
+
+        MultiValuedStatsDMessage(String aspect, Message.Type type, String[] tags, double sampleRate, long timestamp) {
+            super(aspect, type, tags);
+            this.sampleRate = sampleRate;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public final boolean canAggregate() {
+            return false;
+        }
+
+        @Override
+        public final void aggregate(Message message) {
+        }
+
+        @Override
+        public final void writeTo(StringBuilder builder, String containerID) {
+            builder.append(prefix).append(aspect);
+            writeValuesTo(builder);
+            builder.append('|').append(type);
+            if (!Double.isNaN(sampleRate)) {
+                builder.append('|').append('@').append(format(SAMPLE_RATE_FORMATTER, sampleRate));
+            }
+            if (timestamp != 0) {
+                builder.append("|T").append(timestamp);
+            }
+            tagString(tags, builder);
+            if (containerID != null && !containerID.isEmpty()) {
+                builder.append("|c:").append(containerID);
+            }
+
+            builder.append('\n');
+        }
+
+        protected abstract void writeValuesTo(StringBuilder builder);
+    }
+
+    final class LongsStatsDMessage extends MultiValuedStatsDMessage {
+        private final long[] values;
+
+        LongsStatsDMessage(String aspect, Message.Type type, long[] values, double sampleRate, long timestamp, String[] tags) {
+            super(aspect, type, tags, sampleRate, timestamp);
+            this.values = values;
+        }
+
+        @Override
+        protected void writeValuesTo(StringBuilder builder) {
+            for (long value : values) {
+                builder.append(':').append(value);
+            }
+        }
+    }
+
+    final class DoublesStatsDMessage extends MultiValuedStatsDMessage {
+        private final double[] values;
+
+        DoublesStatsDMessage(String aspect, Message.Type type, double[] values, double sampleRate, long timestamp,
+                             String[] tags) {
+            super(aspect, type, tags, sampleRate, timestamp);
+            this.values = values;
+        }
+
+        @Override
+        protected void writeValuesTo(StringBuilder builder) {
+            for (double value : values) {
+                builder.append(':').append(value);
+            }
+        }
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingDirectStatsDClient.java
@@ -94,6 +94,10 @@ final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implem
         }
 
         private boolean writeValuesTo(StringBuilder builder, int remainingCapacity) {
+            if (offset >= lengthOfValues()) {
+                return false;
+            }
+
             int maxLength = builder.length() + remainingCapacity;
 
             // Add at least one value
@@ -107,7 +111,7 @@ final class NonBlockingDirectStatsDClient extends NonBlockingStatsDClient implem
                 writeValueTo(builder, i);
                 if (builder.length() > maxLength) {
                     builder.setLength(previousLength);
-                    offset += i;
+                    offset = i;
                     return true;
                 }
                 previousLength = builder.length();

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -526,7 +526,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
 
         @Override
-        public final void writeTo(StringBuilder builder, String containerID) {
+        public final boolean writeTo(StringBuilder builder, int capacity, String containerID) {
             builder.append(prefix).append(aspect).append(':');
             writeValue(builder);
             builder.append('|').append(type);
@@ -542,6 +542,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             }
 
             builder.append('\n');
+            return false;
         }
 
         @Override
@@ -1145,7 +1146,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     @Override
     public void recordEvent(final Event event, final String... eventTags) {
         statsDProcessor.send(new AlphaNumericMessage(Message.Type.EVENT, "") {
-            @Override public void writeTo(StringBuilder builder, String containerID) {
+            @Override public boolean writeTo(StringBuilder builder, int capacity, String containerID) {
                 final String title = escapeEventString(prefix + event.getTitle());
                 final String text = escapeEventString(event.getText());
                 builder.append(Message.Type.EVENT.toString())
@@ -1168,6 +1169,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 }
 
                 builder.append('\n');
+                return false;
             }
         });
         this.telemetry.incrEventsSent(1);
@@ -1200,13 +1202,14 @@ public class NonBlockingStatsDClient implements StatsDClient {
     @Override
     public void recordServiceCheckRun(final ServiceCheck sc) {
         statsDProcessor.send(new AlphaNumericMessage(Message.Type.SERVICE_CHECK, "") {
-            @Override public void writeTo(StringBuilder sb, String containerID) {
+            @Override
+            public boolean writeTo(StringBuilder sb, int capacity, String containerID) {
                 // see http://docs.datadoghq.com/guides/dogstatsd/#service-checks
                 sb.append(Message.Type.SERVICE_CHECK.toString())
-                    .append("|")
-                    .append(sc.getName())
-                    .append("|")
-                    .append(sc.getStatus());
+                        .append("|")
+                        .append(sc.getName())
+                        .append("|")
+                        .append(sc.getStatus());
                 if (sc.getTimestamp() > 0) {
                     sb.append("|d:").append(sc.getTimestamp());
                 }
@@ -1222,6 +1225,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 }
 
                 sb.append('\n');
+                return false;
             }
         });
         this.telemetry.incrServiceChecksSent(1);
@@ -1286,7 +1290,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 builder.append(getValue());
             }
 
-            @Override protected final void writeTo(StringBuilder builder, String containerID) {
+            @Override
+            protected final boolean writeTo(StringBuilder builder, int capacity, String containerID) {
                 builder.append(prefix).append(aspect).append(':');
                 writeValue(builder);
                 builder.append('|').append(type);
@@ -1296,6 +1301,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 }
 
                 builder.append('\n');
+                return false;
             }
         });
     }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -161,7 +161,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         return formatter.get().format(value);
     }
 
-    private final String prefix;
+    final String prefix;
     private final ClientChannel clientChannel;
     private final ClientChannel telemetryClientChannel;
     private final StatsDClientErrorHandler handler;
@@ -247,7 +247,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
      * @throws StatsDClientException
      *     if the client could not be started
      */
-    private NonBlockingStatsDClient(final String prefix, final int queueSize, final String[] constantTags,
+    NonBlockingStatsDClient(final String prefix, final int queueSize, final String[] constantTags,
             final StatsDClientErrorHandler errorHandler, final Callable<SocketAddress> addressLookup,
             final Callable<SocketAddress> telemetryAddressLookup, final int timeout, final int bufferSize,
             final int maxPacketSizeBytes, String entityID, final int poolSize, final int processorWorkers,
@@ -554,7 +554,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     }
 
 
-    private boolean sendMetric(final Message message) {
+    boolean sendMetric(final Message message) {
         return send(message);
     }
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -212,6 +212,18 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
     }
 
     /**
+     * {@link DirectStatsDClient} factory method.
+     *
+     * <p>It is an experimental extension of {@link StatsDClient} that allows for direct access to some dogstatsd features.
+     * It is not recommended to use this client in production.
+     * @return the built DirectStatsDClient.
+     * @see DirectStatsDClient
+     */
+    public DirectStatsDClient buildDirectStatsDClient() throws StatsDClientException {
+        return new NonBlockingDirectStatsDClient(resolve());
+    }
+
+    /**
      * Creates a copy of this builder with any implicit elements resolved.
      * @return the resolved copy of the builder.
      */

--- a/src/main/java/com/timgroup/statsd/Telemetry.java
+++ b/src/main/java/com/timgroup/statsd/Telemetry.java
@@ -69,7 +69,7 @@ public class Telemetry {
         }
 
         @Override
-        public final void writeTo(StringBuilder builder, String containerID) {
+        public final boolean writeTo(StringBuilder builder, int capacity, String containerID) {
             builder.append(aspect)
                 .append(':')
                 .append(this.value)
@@ -82,6 +82,7 @@ public class Telemetry {
             }
 
             builder.append('\n');  // already has the statsd separator baked-in
+            return false;
         }
     }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingDirectStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingDirectStatsDClientTest.java
@@ -96,14 +96,20 @@ public class NonBlockingDirectStatsDClientTest {
 
     @Test(timeout = 5000L)
     public void sends_too_long_multivalued_distribution_to_statsd() {
-        long[] values = {423L, 234L, 456L, 512L};
+        long[] values = {423L, 234L, 456L, 512L, 345L, 898L, 959876543123L, 667L};
         client.recordDistributionValues("mydistribution", values, 1, "foo:bar", "baz");
 
         server.waitForMessage("my.prefix");
         assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423:234:456|d|@1.000000|#baz,foo:bar")));
 
         server.waitForMessage("my.prefix");
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:512|d|@1.000000|#baz,foo:bar")));
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:512:345:898|d|@1.000000|#baz,foo:bar")));
+
+        server.waitForMessage("my.prefix");
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:959876543123|d|@1.000000|#baz,foo:bar")));
+
+        server.waitForMessage("my.prefix");
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:667|d|@1.000000|#baz,foo:bar")));
     }
 
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingDirectStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingDirectStatsDClientTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.hasItem;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class NonBlockingDirectStatsDClientTest {
 
-    private static final int STATSD_SERVER_PORT = 17254;
+    private static final int STATSD_SERVER_PORT = 17256;
     private static final int MAX_PACKET_SIZE = 64;
     private static DirectStatsDClient client;
     private static DummyStatsDServer server;

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1556,8 +1556,8 @@ public class NonBlockingStatsDClientTest {
             }
 
             @Override
-            void writeTo(StringBuilder builder, String containerID) {
-
+            boolean writeTo(StringBuilder builder, int capacity, String containerID) {
+                return false;
             }
         }
         AlphaNumericMessage alphaNum1 = new TestAlphaNumericMessage("my.count", Message.Type.COUNT, "value", new String[] {"tag"});

--- a/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDAggregatorTest.java
@@ -56,7 +56,9 @@ public class StatsDAggregatorTest {
         }
 
         @Override
-        protected void writeTo(StringBuilder builder, String containerID){}
+        protected boolean writeTo(StringBuilder builder, int capacity, String containerID) {
+            return false;
+        }
     }
 
     public static class FakeAlphaMessage extends AlphaNumericMessage {
@@ -65,7 +67,9 @@ public class StatsDAggregatorTest {
         }
 
         @Override
-        protected void writeTo(StringBuilder builder, String containerID){}
+        protected boolean writeTo(StringBuilder builder, int capacity, String containerID) {
+            return false;
+        }
     }
 
 
@@ -268,8 +272,8 @@ public class StatsDAggregatorTest {
         for (int i = 0; i < numMessages; i++) {
             fakeProcessor.send(new NumericMessage<Integer>("some.counter", Message.Type.COUNT, 1, tags[i % numTags]) {
                 @Override
-                void writeTo(StringBuilder builder, String containerID) {
-
+                boolean writeTo(StringBuilder builder, int capacity, String containerID) {
+                    return false;
                 }
 
                 @Override

--- a/src/test/java/com/timgroup/statsd/StatsDTestMessage.java
+++ b/src/test/java/com/timgroup/statsd/StatsDTestMessage.java
@@ -9,7 +9,7 @@ class StatsDTestMessage<T extends Number> extends NumericMessage<T> {
     }
 
     @Override
-    public final void writeTo(StringBuilder builder, String containerID) {
+    public final boolean writeTo(StringBuilder builder, int capacity, String containerID) {
         builder.append("test.").append(aspect).append(':');
         writeValue(builder);
         builder.append('|').append(type);
@@ -22,6 +22,7 @@ class StatsDTestMessage<T extends Number> extends NumericMessage<T> {
         }
 
         builder.append('\n');
+        return false;
     }
 
     protected void writeValue(StringBuilder builder) {

--- a/src/test/java/com/timgroup/statsd/TelemetryTest.java
+++ b/src/test/java/com/timgroup/statsd/TelemetryTest.java
@@ -70,7 +70,7 @@ public class TelemetryTest {
             ArrayList<String> stringMessages = new ArrayList<>(messages.size());
             for(Message m : messages) {
                 sb.setLength(0);
-                m.writeTo(sb, this.containerID);
+                m.writeTo(sb, Integer.MAX_VALUE, this.containerID);
                 stringMessages.add(sb.toString());
             }
             return stringMessages;


### PR DESCRIPTION
recordDistributionValues is similar to recordDistributionValue but it lets the client sends multiple samples in one message using dogstatsd 1.1 protocol.

Because this is a shift compared to how other methods are behaving, these methods are provided only in DirectStatsDClient which provides direct access to some low level dogstatsd protocol features.

This is recommended in high performance cases were the overhead of the statsd library might be significant and the sampling is already done by the client.

Port of https://github.com/DataDog/datadog-go/pull/296.