### PR TITLE
AMLII-1487 Fix windows-opendjk12 CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,11 @@ jobs:
 #    <<: *default_steps
 
   windows-openjdk12:
-    executor: win/default
+    executor:
+      # https://github.com/CircleCI-Public/windows-orb/blob/v2.4.1/src/executors/default.yml
+      name: win/default
+      # https://circleci.com/developer/machine/image/windows-server-2019
+      version: 2023.04.1
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
       version: 2023.04.1
     steps:
       - checkout
+      - run: java -version
       - run: |
           choco install maven
       - run: |


### PR DESCRIPTION
Pin the image version used for the CI job, so it doesn't get updated behind the scenes with newer JDK.
