### PR TITLE
Origin Detection: Send both container ID and entity ID

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -276,7 +276,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                 }
             }
             // Support "dd.internal.entity_id" internal tag.
-            final boolean hasEntityID = updateTagsWithEntityID(costantPreTags, entityID);
+            updateTagsWithEntityID(costantPreTags, entityID);
             for (final Literal literal : Literal.values()) {
                 final String envVal = literal.envVal();
                 if (envVal != null && !envVal.trim().isEmpty()) {
@@ -291,12 +291,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
             }
             costantPreTags = null;
             // Origin detection
-            if (hasEntityID) {
-                containerID = null;
-            } else {
-                boolean originEnabled = isOriginDetectionEnabled(containerID, originDetectionEnabled, hasEntityID);
-                containerID = getContainerID(containerID, originEnabled);
-            }
+            boolean originEnabled = isOriginDetectionEnabled(containerID, originDetectionEnabled);
+            containerID = getContainerID(containerID, originEnabled);
         }
 
         try {
@@ -1310,10 +1306,9 @@ public class NonBlockingStatsDClient implements StatsDClient {
         return sampleRate != 1 && ThreadLocalRandom.current().nextDouble() > sampleRate;
     }
 
-    boolean isOriginDetectionEnabled(String containerID, boolean originDetectionEnabled, boolean hasEntityID) {
-        if (!originDetectionEnabled || hasEntityID || (containerID != null && !containerID.isEmpty())) {
+    boolean isOriginDetectionEnabled(String containerID, boolean originDetectionEnabled) {
+        if (!originDetectionEnabled || (containerID != null && !containerID.isEmpty())) {
             // origin detection is explicitly disabled
-            // or DD_ENTITY_ID was found
             // or a user-defined container ID was provided
             return false;
         }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -837,7 +837,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout = 5000L)
     public void init_client_from_env_vars() throws Exception {
-        final String entity_value =  "foo-entity";
+        final String entity_value = "foo-entity";
         environmentVariables.set(NonBlockingStatsDClient.DD_DOGSTATSD_PORT_ENV_VAR, Integer.toString(STATSD_SERVER_PORT));
         environmentVariables.set(NonBlockingStatsDClient.DD_AGENT_HOST_ENV_VAR, "localhost");
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
@@ -1661,7 +1661,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout = 5000L)
     public void test_entity_id_and_container_id() throws Exception {
-        final String entity_value =  "foo-entity";
+        final String entity_value = "foo-entity";
         environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -739,7 +739,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage();
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
         } finally {
             client.stop();
         }
@@ -829,7 +829,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
         } finally {
             client.stop();
         }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -835,7 +835,6 @@ public class NonBlockingStatsDClientTest {
         }
     }
 
-
     @Test(timeout = 5000L)
     public void init_client_from_env_vars() throws Exception {
         final String entity_value =  "foo-entity";

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1661,6 +1661,27 @@ public class NonBlockingStatsDClientTest {
     }
 
     @Test(timeout = 5000L)
+    public void test_entity_id_and_container_id() throws Exception {
+        final String entity_value =  "foo-entity";
+        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+        .prefix("my.prefix")
+        .hostname("localhost")
+        .port(STATSD_SERVER_PORT)
+        .enableTelemetry(false)
+        .containerID("fake-container-id")
+        .build();
+        try {
+            client.gauge("value", 423);
+            server.waitForMessage();
+
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
+        } finally {
+            client.stop();
+        }
+    }
+
+    @Test(timeout = 5000L)
     public void origin_detection_env_false() throws Exception {
         environmentVariables.set(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR, "false");
 
@@ -1673,7 +1694,7 @@ public class NonBlockingStatsDClientTest {
             .enableTelemetry(false)
             .build();
 
-        assertFalse(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION, false));
+        assertFalse(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
         environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
     }
 
@@ -1690,7 +1711,7 @@ public class NonBlockingStatsDClientTest {
             .enableTelemetry(false)
             .build();
 
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION, false));
+        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
         environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
     }
 
@@ -1705,7 +1726,7 @@ public class NonBlockingStatsDClientTest {
             .enableTelemetry(false)
             .build();
 
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION, false));
+        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
     }
 
     @Test(timeout = 5000L)
@@ -1719,7 +1740,7 @@ public class NonBlockingStatsDClientTest {
             .enableTelemetry(false)
             .build();
 
-        assertFalse(client.isOriginDetectionEnabled(null, false, false));
+        assertFalse(client.isOriginDetectionEnabled(null, false));
     }
 
     private static class SlowStatsDNonBlockingStatsDClient extends NonBlockingStatsDClient {

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -714,12 +714,13 @@ public class NonBlockingStatsDClientTest {
             .hostname("localhost")
             .port(STATSD_SERVER_PORT)
             .queueSize(Integer.MAX_VALUE)
+            .containerID("fake-container-id")
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
         } finally {
             client.stop();
         }
@@ -734,12 +735,13 @@ public class NonBlockingStatsDClientTest {
             .hostname("localhost")
             .port(STATSD_SERVER_PORT)
             .queueSize(Integer.MAX_VALUE)
+            .containerID("fake-container-id")
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage();
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
         } finally {
             client.stop();
         }
@@ -756,12 +758,13 @@ public class NonBlockingStatsDClientTest {
             .port(STATSD_SERVER_PORT)
             .queueSize(Integer.MAX_VALUE)
             .constantTags(constantTags)
+            .containerID("fake-container-id")
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags + "|c:fake-container-id")));
         } finally {
             client.stop();
         }
@@ -802,13 +805,14 @@ public class NonBlockingStatsDClientTest {
             .constantTags(null)
             .errorHandler(null)
             .entityID(entity_value+"-arg")
+            .containerID("fake-container-id")
             .build();
 
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg|c:fake-container-id")));
         } finally {
             client.stop();
         }
@@ -824,12 +828,13 @@ public class NonBlockingStatsDClientTest {
             .port(STATSD_SERVER_PORT)
             .queueSize(Integer.MAX_VALUE)
             .entityID(entity_value+"-arg")
+            .containerID("fake-container-id")
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg|c:fake-container-id")));
         } finally {
             client.stop();
         }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -719,7 +719,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
         } finally {
             client.stop();
         }
@@ -761,7 +761,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
+            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
         } finally {
             client.stop();
         }
@@ -808,7 +808,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
         } finally {
             client.stop();
         }
@@ -1665,12 +1665,12 @@ public class NonBlockingStatsDClientTest {
         final String entity_value =  "foo-entity";
         environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-        .prefix("my.prefix")
-        .hostname("localhost")
-        .port(STATSD_SERVER_PORT)
-        .enableTelemetry(false)
-        .containerID("fake-container-id")
-        .build();
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(STATSD_SERVER_PORT)
+            .enableTelemetry(false)
+            .containerID("fake-container-id")
+            .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage();

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -719,7 +719,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
         } finally {
             client.stop();
         }
@@ -739,7 +739,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage();
 
-            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity")));
         } finally {
             client.stop();
         }
@@ -761,7 +761,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
         } finally {
             client.stop();
         }
@@ -808,7 +808,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
         } finally {
             client.stop();
         }
@@ -829,7 +829,7 @@ public class NonBlockingStatsDClientTest {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(startsWith("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
+            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg")));
         } finally {
             client.stop();
         }


### PR DESCRIPTION
We would like customers to be able to retrieve container tags even when DD_ENTITY_ID is set. The current behavior does not send the container-id if the entity id is set.

This PR implements the same changes seen in these PRs:
https://github.com/DataDog/datadog-go/pull/300
https://github.com/DataDog/datadogpy/pull/828

# Background

UDP support for origin detection was first introduced in `7.51` However it was difficult to use due to the [combination of settings required](https://github.com/DataDog/datadog-agent/blob/3b04f2a2e7e606e7ca2a737e231a2e3b8dfd7b59/comp/core/tagger/tagger.go#L378). With 7.54+ you can enable `DD_ORIGIN_DETECTION_UNIFIED` and it will "just work". 

After this change with `DD_ORIGIN_DETECTION_UNIFIED` users can control origin tags by simply changing the `cardinality` setting (to `high` for container level tags). This PR ultimately helps conform to the new origin detection architecture in the agent: Clients should send "Everything" (all data needed for origin detection), the agent should ingest everything, and cardinality controls which tags actually get sent. 

The old behavior is maintained by omitting the `DD_ORIGIN_DETECTION_UNIFIED` in the agent which will cause the tagger to [fall back to legacy mode](https://github.com/DataDog/datadog-agent/blob/d224b9aa3c2d614f2f9a36525553c7c87fa5c2b3/pkg/tagger/types/types.go#L15). This will eventually be removed. 