### PR TITLE
uds-stream: close unused sockets

### DIFF
--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -138,11 +138,9 @@ public class UnixStreamClientChannel implements ClientChannel {
         try {
             if (!delegate.connect(address)) {
                 if (connectionTimeout > 0 && System.nanoTime() > deadline) {
-                    closeSafe(delegate);
                     throw new IOException("Connection timed out");
                 }
                 if (!delegate.finishConnect()) {
-                    closeSafe(delegate);
                     throw new IOException("Connection failed");
                 }
             }
@@ -152,7 +150,11 @@ public class UnixStreamClientChannel implements ClientChannel {
                 delegate.setOption(UnixSocketOptions.SO_SNDBUF, bufferSize);
             }
         } catch (Exception e) {
-            closeSafe(delegate);
+            try {
+                delegate.close();
+            } catch (IOException __) {
+                // ignore
+            }
             throw e;
         }
 
@@ -161,11 +163,7 @@ public class UnixStreamClientChannel implements ClientChannel {
     }
 
     static private void closeSafe(UnixSocketChannel channel) {
-        try {
-            channel.close();
-        } catch (IOException e) {
-            // ignore
-        }
+
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -136,9 +136,11 @@ public class UnixStreamClientChannel implements ClientChannel {
         }
         if (!delegate.connect(address)) {
             if (connectionTimeout > 0 && System.nanoTime() > deadline) {
+                delegate.close();
                 throw new IOException("Connection timed out");
             }
             if (!delegate.finishConnect()) {
+                delegate.close();
                 throw new IOException("Connection failed");
             }
         }

--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -1,6 +1,5 @@
 package com.timgroup.statsd;
 
-import java.net.SocketOption;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
 import jnr.unixsocket.UnixSocketOptions;

--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -160,11 +160,7 @@ public class UnixStreamClientChannel implements ClientChannel {
 
         this.delegate = delegate;
     }
-
-    static private void closeSafe(UnixSocketChannel channel) {
-
-    }
-
+    
     @Override
     public void close() throws IOException {
         disconnect();


### PR DESCRIPTION
We need to make sure we close the socket
file descriptors before forgetting them otherwise
we leak fds.