### PR TITLE
Remove non-public constructor

### DIFF
--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -9,8 +9,6 @@ package com.timgroup.statsd;
  */
 public class NoOpStatsDClient implements StatsDClient {
 
-    NoOpStatsDClient() {}
-
     @Override public void stop() { }
 
     @Override public void close() { }


### PR DESCRIPTION
The constructor is not necessary and prevents downstream code from using NoOpStatsDClient.

Fixes #246