### PR TITLE
AMLII-2058 Use correct buffer size for unix sockets

### DIFF
--- a/src/main/java/com/timgroup/statsd/ClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/ClientChannel.java
@@ -4,4 +4,6 @@ import java.nio.channels.WritableByteChannel;
 
 interface ClientChannel extends WritableByteChannel {
     String getTransportType();
+
+    int getMaxPacketSizeBytes();
 }

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -52,4 +52,9 @@ class DatagramClientChannel implements ClientChannel {
     public String toString() {
         return "[" + getTransportType() + "] " + address;
     }
+
+    @Override
+    public int getMaxPacketSizeBytes() {
+        return NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES;
+    }
 }

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -48,4 +48,9 @@ class NamedPipeClientChannel implements ClientChannel {
     public String toString() {
         return pipe;
     }
+
+    @Override
+    public int getMaxPacketSizeBytes() {
+        return NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES;
+    }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -236,13 +236,7 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
             throw new UnsupportedOperationException("clone");
         }
 
-        int packetSize = maxPacketSizeBytes;
         Callable<SocketAddress> lookup = getAddressLookup();
-
-        if (packetSize == 0) {
-            packetSize = (port == 0) ? NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES :
-                NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES;
-        }
 
         Callable<SocketAddress> telemetryLookup = telemetryAddressLookup;
         if (telemetryLookup == null) {
@@ -253,7 +247,6 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
             }
         }
 
-        resolved.maxPacketSizeBytes = packetSize;
         resolved.addressLookup = lookup;
         resolved.telemetryAddressLookup = telemetryLookup;
 

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -31,4 +31,9 @@ class UnixDatagramClientChannel extends DatagramClientChannel {
     public String getTransportType() {
         return "uds";
     }
+
+    @Override
+    public int getMaxPacketSizeBytes() {
+        return NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES;
+    }
 }

--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -175,4 +175,9 @@ public class UnixStreamClientChannel implements ClientChannel {
     public String toString() {
         return "[" + getTransportType() + "] " + address;
     }
+
+    @Override
+    public int getMaxPacketSizeBytes() {
+        return NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES;
+    }
 }

--- a/src/test/java/com/timgroup/statsd/UnixStreamSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixStreamSocketTest.java
@@ -171,4 +171,27 @@ public class UnixStreamSocketTest implements StatsDClientErrorHandler {
         assertThat(server.messagesReceived(), hasItem("my.prefix.mycount:30|g"));
         server.clear();
     }
+
+    @Test(timeout = 5000L)
+    public void stream_uds_has_uds_buffer_size() throws Exception {
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .address("unixstream:///foo")
+            .containerID("fake-container-id")
+            .build();
+
+        assertEquals(client.statsDProcessor.bufferPool.getBufferSize(), NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES);
+    }
+
+    @Test(timeout = 5000L)
+    public void max_packet_size_override() throws Exception {
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .address("unixstream:///foo")
+            .containerID("fake-container-id")
+            .maxPacketSizeBytes(576)
+            .build();
+
+        assertEquals(client.statsDProcessor.bufferPool.getBufferSize(), 576);
+    }
 }


### PR DESCRIPTION
When the client is configured to use UDS via builder's address() method, the client defaulted to UDP-sized buffer.

This patch adds a method to the ClientChannel to fetch the default packet size for each transport type, and uses it in the client to pass the correct value to the processor. The maxPacketSizeBytes field of the resolved builder is reduced to only storing the user preferred configuration, if any.