### PR TITLE
AGTMETRICS-61 Optimize utf-8 encoding of payloads

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -615,7 +615,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
 
             sendMetric(new StatsDMessage<Long>(aspect, type, value, sampleRate, timestamp, tags) {
                 @Override protected void writeValue(StringBuilder builder) {
-                    builder.append(this.value);
+                    builder.append(this.value.longValue());
                 }
             });
         }


### PR DESCRIPTION
Optimize client UTF-8 encoding with hand-rolled conversion from UTF-16.

For pure ascii strings, this is much faster than using `CharsetEncoder` the way we were using it (A: 4.4.3, B: this PR).
<img width="1259" alt="Screenshot 2025-03-26 at 20 04 38" src="https://github.com/user-attachments/assets/1e736a32-978a-49b3-87e9-5efc67de273b" />

While the encoding routine itself is slower, overall it runs on par with `String.getBytes` due to fewer allocations and less GC pressure (A: #259, B: this PR)
<img width="1259" alt="Screenshot 2025-03-26 at 20 14 22" src="https://github.com/user-attachments/assets/17d816b7-ae8c-4a9d-b1fc-659ecf6a64da" />

With a few non-ascii characters, it is a bit slower, but still outperforms `CharsetEncoder`.
<img width="1259" alt="Screenshot 2025-03-26 at 20 18 21" src="https://github.com/user-attachments/assets/2971c3f0-6cd9-431d-9bf1-2e518d515878" />

vs String.getBytes()
<img width="1259" alt="Screenshot 2025-03-26 at 20 18 28" src="https://github.com/user-attachments/assets/82494e4a-a3c8-4655-9fa2-f0caa21b1d5d" />

