### PR TITLE
Fix races in the tests

### DIFF
--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -17,14 +17,15 @@ abstract class DummyStatsDServer implements Closeable {
     private AtomicInteger packetsReceived = new AtomicInteger(0);
 
     protected volatile Boolean freeze = false;
+    Thread thread;
 
     protected void listen() {
-        Thread thread = new Thread(new Runnable() {
+        thread = new Thread(new Runnable() {
             @Override
             public void run() {
                 final ByteBuffer packet = ByteBuffer.allocate(DEFAULT_UDS_MAX_PACKET_SIZE_BYTES);
 
-                while(isOpen()) {
+                while(isOpen() && !Thread.interrupted()) {
                     if (freeze) {
                         try {
                             Thread.sleep(10);

--- a/src/test/java/com/timgroup/statsd/UnixSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixSocketTest.java
@@ -105,8 +105,9 @@ public class UnixSocketTest implements StatsDClientErrorHandler {
 
         // Close the server, client should throw an IOException
         server.close();
+
+        client.gauge("mycount", 20);
         while(lastException.getMessage() == null) {
-            client.gauge("mycount", 20);
             Thread.sleep(10);
         }
         assertThat(lastException.getMessage(), containsString("Connection refused"));

--- a/src/test/java/com/timgroup/statsd/UnixStreamSocketTest.java
+++ b/src/test/java/com/timgroup/statsd/UnixStreamSocketTest.java
@@ -108,8 +108,9 @@ public class UnixStreamSocketTest implements StatsDClientErrorHandler {
 
         // Close the server, client should throw an IOException
         server.close();
+
+        client.gauge("mycount", 20);
         while(lastException.getMessage() == null) {
-            client.gauge("mycount", 20);
             Thread.sleep(10);
         }
         // Depending on the state of the client at that point we might get different messages.


### PR DESCRIPTION
resist_dsd_restart for stream and datagram unix socket contained a race when testing server closed condition. Sending multiple payloads in a loop caused a situation when the "Connection refused" error was triggered twice, confusing the following step of the test that expects a different error.

jnr-unixsocket does not interrupt receive call when the server channel is closed, and successfully reads a datagram sent after the call to close.

This patch modifies the server to actually close the socket when instructed and send the test payload once to controllably trigger the error.