### PR TITLE
AGTMETRICS-212 refactor tests

### DIFF
--- a/src/main/java/com/timgroup/statsd/CgroupReader.java
+++ b/src/main/java/com/timgroup/statsd/CgroupReader.java
@@ -57,7 +57,7 @@ class CgroupReader {
 
     /**
      * Returns the container ID if available or the cgroup controller inode.
-     * 
+     *
      * @throws IOException if /proc/self/cgroup is readable and still an I/O error
      *                     occurs reading from the stream.
      */
@@ -78,7 +78,7 @@ class CgroupReader {
          * the container ID.
          * In Host cgroup namespace, the container ID should be found. If it is not
          * found, it means that the application is running on a host/vm.
-         * 
+         *
          */
         if ((containerID == null || containerID.equals("")) && !isHostCgroupNamespace(CGROUP_NS_PATH)) {
             containerID = getCgroupInode(DEFAULT_CGROUP_MOUNT_PATH, cgroupContent);
@@ -88,7 +88,7 @@ class CgroupReader {
 
     /**
      * Returns the content of `path` (=/proc/self/cgroup).
-     * 
+     *
      * @throws IOException if /proc/self/cgroup is readable and still an I/O error
      *                     occurs reading from the stream.
      */
@@ -105,7 +105,7 @@ class CgroupReader {
      * Parses a Cgroup file (=/proc/self/cgroup) content and returns the
      * corresponding container ID. It can be found only if the container
      * is running in host cgroup namespace.
-     * 
+     *
      * @param cgroupsContent Cgroup file content
      */
     public static String parse(final String cgroupsContent) {
@@ -125,7 +125,7 @@ class CgroupReader {
      * Returns true if the host cgroup namespace is used.
      * It looks at the inode of `/proc/self/ns/cgroup` and compares it to
      * HOST_CGROUP_NAMESPACE_INODE.
-     * 
+     *
      * @param path Path to the cgroup namespace file.
      */
     private static boolean isHostCgroupNamespace(final Path path) {
@@ -135,7 +135,7 @@ class CgroupReader {
 
     /**
      * Returns the inode for the given path.
-     * 
+     *
      * @param path Path to the cgroup namespace file.
      */
     private static long inodeForPath(final Path path) {
@@ -150,7 +150,7 @@ class CgroupReader {
     /**
      * Returns the cgroup controller inode for the given cgroup mount path and
      * procSelfCgroupPath.
-     * 
+     *
      * @param cgroupMountPath Path to the cgroup mount point.
      * @param cgroupContent   String content of the cgroup file.
      */
@@ -183,7 +183,7 @@ class CgroupReader {
 
     /**
      * Returns a map of cgroup controllers and their corresponding cgroup path.
-     * 
+     *
      * @param cgroupContent Cgroup file content.
      */
     public static Map<String, String> parseCgroupNodePath(final String cgroupContent) throws IOException {

--- a/src/main/java/com/timgroup/statsd/MapUtils.java
+++ b/src/main/java/com/timgroup/statsd/MapUtils.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class MapUtils {
 
     private static final MethodHandle MAP_PUT_IF_ABSENT = buildMapPutIfAbsent();
-    
+
     /**
      * Emulates {@code Map.putIfAbsent} semantics. Replace when baselining at JDK8+.
      * @return the previous value associated with the message, or null if the value was not seen before

--- a/src/main/java/com/timgroup/statsd/Message.java
+++ b/src/main/java/com/timgroup/statsd/Message.java
@@ -142,7 +142,7 @@ public abstract class Message implements Comparable<Message> {
 
         return false;
     }
-    
+
     @Override
     public int compareTo(Message message) {
         int typeComparison = getType().compareTo(message.getType());

--- a/src/main/java/com/timgroup/statsd/StatsDClientException.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClientException.java
@@ -4,9 +4,9 @@ package com.timgroup.statsd;
 /**
  * Signals that an exception has occurred when trying to start the
  * StatsD client.
- * 
+ *
  * @author Tom Denley
- * 
+ *
  */
 public final class StatsDClientException extends RuntimeException {
 

--- a/src/test/java/com/timgroup/statsd/AggregationTest.java
+++ b/src/test/java/com/timgroup/statsd/AggregationTest.java
@@ -1,0 +1,142 @@
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
+
+public class AggregationTest {
+    private UDPDummyStatsDServer server;
+    private NonBlockingStatsDClient testClient;
+
+    @Before
+    public void start() throws IOException {
+        server = new UDPDummyStatsDServer(0);
+        testClient = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(server.getPort())
+            .enableTelemetry(true)
+            .enableAggregation(true)
+            .aggregationFlushInterval(100)
+            // should be larger than aggregation interval to make sure test cases get clean
+            // flush with only metrics they sent.
+            .telemetryFlushInterval(500)
+            .originDetectionEnabled(false)
+            .build();
+    }
+
+    @After
+    public void stop() throws IOException {
+        server.close();
+        testClient.stop();
+    }
+
+    @Test(timeout=5000L)
+    public void testBasicGaugeAggregation() throws Exception {
+        for (int i=0 ; i<10 ; i++) {
+            testClient.gauge("top.level.value", i);
+        }
+        server.waitForMessage("my.prefix");
+
+        List<String> messages = server.messagesReceived();
+
+        assertThat(messages.size(), comparesEqualTo(1));
+        assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.value:9|g")));
+    }
+
+    @Test(timeout=5000L)
+    public void testBasicCountAggregation() throws Exception {
+        for (int i=0 ; i<10 ; i++) {
+            testClient.count("top.level.count", i);
+        }
+        for (int i=0 ; i<10 ; i++) {
+            testClient.increment("top.level.count");
+        }
+
+        server.waitForMessage("my.prefix");
+
+        List<String> messages = server.messagesReceived();
+
+        assertThat(messages.size(), comparesEqualTo(1));
+        assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.count:55|c")));
+    }
+
+    @Test(timeout=5000L)
+    public void testSampledCountAggregation() throws Exception {
+        for (int i=0 ; i<10 ; i++) {
+            // NOTE: because aggregation is enabled, sampling is disabled, so all
+            // counts should be accounted for, as if sample rate were 1.0.
+            testClient.count("top.level.count", i, 0.1);
+        }
+        for (int i=0 ; i<10 ; i++) {
+            testClient.increment("top.level.count");
+        }
+
+        server.waitForMessage("my.prefix");
+
+        List<String> messages = server.messagesReceived();
+
+        assertThat(messages.size(), comparesEqualTo(1));
+        assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.count:55|c")));
+    }
+
+    @Test(timeout=5000L)
+    public void testBasicSetAggregation() throws Exception {
+        for (int i=0 ; i<10 ; i++) {
+            testClient.recordSetValue("top.level.set", "foo", null);
+            testClient.recordSetValue("top.level.set", "bar", null);
+        }
+
+        server.waitForMessage("my.prefix");
+
+        List<String> messages = server.messagesReceived();
+
+        assertThat(messages.size(), comparesEqualTo(2));
+        assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.set:foo|s")));
+        assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.set:bar|s")));
+    }
+
+    @Test(timeout=5000L)
+    public void testAggregationTelemetry() throws Exception {
+        for (int i=0 ; i<10 ; i++) {
+            testClient.gauge("top.level.value", i);
+        }
+        for (int i=0 ; i<10 ; i++) {
+            testClient.count("top.level.count", i);
+        }
+        for (int i=0 ; i<10 ; i++) {
+            testClient.increment("top.level.count.other");
+        }
+
+        server.waitForMessage("datadog");
+
+        List<String> messages = server.messagesReceived();
+
+        assertThat(messages.size(), comparesEqualTo(3+17));
+        assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.aggregated_context:27|c")));
+    }
+
+    @Test(timeout=5000L)
+    public void testBasicUnaggregatedMetrics() throws Exception {
+        int submitted = 0;
+        for (int i=0 ; i<10 ; i++) {
+            testClient.histogram("top.level.hist", i);
+            testClient.distribution("top.level.dist", i);
+            testClient.time("top.level.time", i);
+            submitted += 3;
+        }
+        server.waitForMessage("my.prefix");
+
+        List<String> messages = server.messagesReceived();
+
+        // there should be one message per
+        assertThat(messages.size(), comparesEqualTo(submitted));
+    }
+}

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientBuilderTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientBuilderTest.java
@@ -1,0 +1,89 @@
+package com.timgroup.statsd;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class NonBlockingStatsDClientBuilderTest {
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @Test(timeout = 5000L)
+    public void origin_detection_env_false() throws Exception {
+        environmentVariables.set(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR, "false");
+
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(8125)
+            .queueSize(Integer.MAX_VALUE)
+            .errorHandler(null)
+            .enableTelemetry(false)
+            .build();
+
+        assertFalse(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+        environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
+    }
+
+    @Test(timeout = 5000L)
+    public void origin_detection_env_unknown() throws Exception {
+        environmentVariables.set(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR, "unknown"); // default to true
+
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(8125)
+            .queueSize(Integer.MAX_VALUE)
+            .errorHandler(null)
+            .enableAggregation(false)
+            .enableTelemetry(false)
+            .build();
+
+        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+        environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
+    }
+
+    @Test(timeout = 5000L)
+    public void origin_detection_env_unset() throws Exception {
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(8125)
+            .queueSize(Integer.MAX_VALUE)
+            .errorHandler(null)
+            .enableAggregation(false)
+            .enableTelemetry(false)
+            .build();
+
+        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+    }
+
+    @Test(timeout = 5000L)
+    public void origin_detection_arg_false() throws Exception {
+        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
+            .prefix("my.prefix")
+            .hostname("localhost")
+            .port(8125)
+            .queueSize(Integer.MAX_VALUE)
+            .errorHandler(null)
+            .enableTelemetry(false)
+            .build();
+
+        assertFalse(client.isOriginDetectionEnabled(null, false));
+    }
+
+    @Test(timeout = 5000L)
+    public void address_resolution_empty() throws Exception {
+        assertThrows(StatsDClientException.class, new ThrowingRunnable() {
+                @Override
+                public void run() {
+                    new NonBlockingStatsDClientBuilder().resolve();
+                }
+            });
+    }
+}

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -2,14 +2,16 @@ package com.timgroup.statsd;
 
 
 import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -42,60 +44,72 @@ import static org.junit.Assert.assertThrows;
 import org.junit.function.ThrowingRunnable;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@RunWith(Parameterized.class)
 public class NonBlockingStatsDClientTest {
 
     private static final int STATSD_SERVER_PORT = 17254;
-    private static NonBlockingStatsDClient client;
-    private static NonBlockingStatsDClient clientUnaggregated;
-    private static NonBlockingStatsDClient clientWithContainerID;
-    private static DummyStatsDServer server;
+    private NonBlockingStatsDClient client;
+    private NonBlockingStatsDClient clientUnaggregated;
+    private static UDPDummyStatsDServer server;
 
     private static Logger log = Logger.getLogger("NonBlockingStatsDClientTest");
+
+    private String containerID;
+    private String payloadTail;
+
+    @Parameters
+    public static Object[][] parameters() {
+        return new Object[][]{
+            { null },
+            { "fake-container-id" },
+        };
+    }
+
+    public NonBlockingStatsDClientTest(String containerID) {
+        this.containerID = containerID;
+
+        StringBuilder sb = new StringBuilder();
+        if (containerID != null) {
+            sb.append("|c:").append(containerID);
+        }
+        payloadTail = sb.toString();
+    }
 
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
-    @BeforeClass
-    public static void start() throws IOException {
-        server = new UDPDummyStatsDServer(STATSD_SERVER_PORT);
+    @Before
+    public void start() throws IOException {
+        server = new UDPDummyStatsDServer(0);
         client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .enableTelemetry(false)
             .originDetectionEnabled(false)
+            .aggregationFlushInterval(100)
+            .containerID(containerID)
             .build();
         clientUnaggregated = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .enableTelemetry(false)
             .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
-        clientWithContainerID = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)
-            .containerID("fake-container-id")
-            .build();
-    }
-
-    @AfterClass
-    public static void stop() {
-        try {
-            client.stop();
-            clientUnaggregated.stop();
-            clientWithContainerID.stop();
-            server.close();
-        } catch (java.io.IOException ignored) {
-        }
     }
 
     @After
-    public void clear() {
-        server.clear();
+    public void stop() throws IOException {
+        client.stop();
+        clientUnaggregated.stop();
+        server.close();
+    }
+
+    private void assertPayload(String payloadHead) {
+        assertThat(server.messagesReceived(), hasItem(comparesEqualTo(payloadHead + payloadTail)));
     }
 
     @Test
@@ -109,7 +123,7 @@ public class NonBlockingStatsDClientTest {
         client.count("mycount", 24);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c")));
+        assertPayload("my.prefix.mycount:24|c");
     }
 
     @Test(timeout = 5000L)
@@ -118,7 +132,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.count("mycount", 24, 1);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|@1.000000")));
+        assertPayload("my.prefix.mycount:24|c|@1.000000");
     }
 
     @Test(timeout = 5000L)
@@ -127,7 +141,7 @@ public class NonBlockingStatsDClientTest {
         client.count("mycount", 24, (java.lang.String[]) null);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c")));
+        assertPayload("my.prefix.mycount:24|c");
     }
 
     @Test(timeout = 5000L)
@@ -136,7 +150,7 @@ public class NonBlockingStatsDClientTest {
         client.count("mycount", 24);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c")));
+        assertPayload("my.prefix.mycount:24|c");
     }
 
     @Test(timeout = 5000L)
@@ -145,7 +159,7 @@ public class NonBlockingStatsDClientTest {
         client.count("mycount", 24, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24|c|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -154,7 +168,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.count("mycount", 24, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24|c|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -163,8 +177,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.countWithTimestamp("mycount", 42l, 1032127200, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|T1032127200|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:42|c|T1032127200|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24|c|T1032127200|#baz,foo:bar");
+        assertPayload("my.prefix.mycount:42|c|T1032127200|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -173,8 +187,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.countWithTimestamp("mycount", 42.5d, 1032127200, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24.5|c|T1032127200|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:42.5|c|T1032127200|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24.5|c|T1032127200|#baz,foo:bar");
+        assertPayload("my.prefix.mycount:42.5|c|T1032127200|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -183,8 +197,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.countWithTimestamp("mycount", 42l, 0, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24|c|T1|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:42|c|T1|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24|c|T1|#baz,foo:bar");
+        assertPayload("my.prefix.mycount:42|c|T1|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -193,8 +207,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.countWithTimestamp("mycount", 42.5d, 0, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:24.5|c|T1|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mycount:42.5|c|T1|#baz,foo:bar")));
+        assertPayload("my.prefix.mycount:24.5|c|T1|#baz,foo:bar");
+        assertPayload("my.prefix.mycount:42.5|c|T1|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -203,7 +217,7 @@ public class NonBlockingStatsDClientTest {
         client.incrementCounter("myinc");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myinc:1|c")));
+        assertPayload("my.prefix.myinc:1|c");
     }
 
     @Test(timeout = 5000L)
@@ -212,7 +226,7 @@ public class NonBlockingStatsDClientTest {
         client.incrementCounter("myinc", "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myinc:1|c|#baz,foo:bar")));
+        assertPayload("my.prefix.myinc:1|c|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -221,7 +235,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.incrementCounter("myinc", 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myinc:1|c|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.myinc:1|c|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -230,7 +244,7 @@ public class NonBlockingStatsDClientTest {
         client.decrementCounter("mydec");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydec:-1|c")));
+        assertPayload("my.prefix.mydec:-1|c");
     }
 
     @Test(timeout = 5000L)
@@ -239,7 +253,7 @@ public class NonBlockingStatsDClientTest {
         client.decrementCounter("mydec", "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydec:-1|c|#baz,foo:bar")));
+        assertPayload("my.prefix.mydec:-1|c|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -248,7 +262,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.decrementCounter("mydec", 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydec:-1|c|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.mydec:-1|c|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -258,7 +272,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g")));
+        assertPayload("my.prefix.mygauge:423|g");
     }
 
     // Test that we don't leave partially encoded message in the
@@ -270,9 +284,11 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .errorHandler(errorHandler)
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
 
         try {
@@ -292,8 +308,8 @@ public class NonBlockingStatsDClientTest {
             assertThat(errorHandler.getExceptions(), hasItem(isA(BufferOverflowException.class)));
 
             assertThat(server.messagesReceived(), hasSize(2));
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("mygauge:423|g")));
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("marker:1|g")));
+            assertPayload("mygauge:423|g");
+            assertPayload("marker:1|g");
             assertThat(server.messagesReceived(), not(hasItem(startsWith("badgauge"))));
         } finally {
             client.stop();
@@ -306,7 +322,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordGaugeValue("mygauge", 423, 1);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|@1.000000")));
+        assertPayload("my.prefix.mygauge:423|g|@1.000000");
     }
 
     @Test(timeout = 5000L)
@@ -316,7 +332,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 123456789012345.67890);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:123456789012345.67|g")));
+        assertPayload("my.prefix.mygauge:123456789012345.67|g");
     }
 
     @Test(timeout = 5000L)
@@ -326,7 +342,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 123.45678901234567890);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:123.456789|g")));
+        assertPayload("my.prefix.mygauge:123.456789|g");
     }
 
     @Test(timeout = 5000L)
@@ -336,7 +352,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 0.423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:0.423|g")));
+        assertPayload("my.prefix.mygauge:0.423|g");
     }
 
     @Test(timeout = 5000L)
@@ -346,7 +362,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:423|g|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -355,7 +371,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordGaugeValue("mygauge", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:423|g|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -364,8 +380,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.gaugeWithTimestamp("mygauge", 423l, 1205794800, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:234|g|T1205794800|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|T1205794800|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:234|g|T1205794800|#baz,foo:bar");
+        assertPayload("my.prefix.mygauge:423|g|T1205794800|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -374,8 +390,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.gaugeWithTimestamp("mygauge", 423.5d, 1205794800, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:243.5|g|T1205794800|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423.5|g|T1205794800|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:243.5|g|T1205794800|#baz,foo:bar");
+        assertPayload("my.prefix.mygauge:423.5|g|T1205794800|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -384,8 +400,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.gaugeWithTimestamp("mygauge", 423l, -1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:234|g|T1|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423|g|T1|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:234|g|T1|#baz,foo:bar");
+        assertPayload("my.prefix.mygauge:423|g|T1|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -394,8 +410,8 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.gaugeWithTimestamp("mygauge", 423.5d, -1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:243.5|g|T1|#baz,foo:bar")));
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:423.5|g|T1|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:243.5|g|T1|#baz,foo:bar");
+        assertPayload("my.prefix.mygauge:423.5|g|T1|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -405,7 +421,7 @@ public class NonBlockingStatsDClientTest {
         client.recordGaugeValue("mygauge", 0.423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:0.423|g|#baz,foo:bar")));
+        assertPayload("my.prefix.mygauge:0.423|g|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -414,7 +430,7 @@ public class NonBlockingStatsDClientTest {
         client.recordHistogramValue("myhistogram", 423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:423|h")));
+        assertPayload("my.prefix.myhistogram:423|h");
     }
 
     @Test(timeout = 5000L)
@@ -424,7 +440,7 @@ public class NonBlockingStatsDClientTest {
         client.recordHistogramValue("myhistogram", 0.423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:0.423|h")));
+        assertPayload("my.prefix.myhistogram:0.423|h");
     }
 
     @Test(timeout = 5000L)
@@ -434,7 +450,7 @@ public class NonBlockingStatsDClientTest {
         client.recordHistogramValue("myhistogram", 423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:423|h|#baz,foo:bar")));
+        assertPayload("my.prefix.myhistogram:423|h|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -443,7 +459,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordHistogramValue("myhistogram", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:423|h|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.myhistogram:423|h|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -453,7 +469,7 @@ public class NonBlockingStatsDClientTest {
         client.recordHistogramValue("myhistogram", 0.423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:0.423|h|#baz,foo:bar")));
+        assertPayload("my.prefix.myhistogram:0.423|h|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -462,7 +478,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordHistogramValue("myhistogram", 0.423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myhistogram:0.423|h|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.myhistogram:0.423|h|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -471,7 +487,7 @@ public class NonBlockingStatsDClientTest {
         client.recordDistributionValue("mydistribution", 423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423|d")));
+        assertPayload("my.prefix.mydistribution:423|d");
     }
 
     @Test(timeout = 5000L)
@@ -481,7 +497,7 @@ public class NonBlockingStatsDClientTest {
         client.recordDistributionValue("mydistribution", 0.423);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423|d")));
+        assertPayload("my.prefix.mydistribution:0.423|d");
     }
 
     @Test(timeout = 5000L)
@@ -491,7 +507,7 @@ public class NonBlockingStatsDClientTest {
         client.recordDistributionValue("mydistribution", 423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423|d|#baz,foo:bar")));
+        assertPayload("my.prefix.mydistribution:423|d|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -500,7 +516,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordDistributionValue("mydistribution", 423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:423|d|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.mydistribution:423|d|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -510,7 +526,7 @@ public class NonBlockingStatsDClientTest {
         client.recordDistributionValue("mydistribution", 0.423, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423|d|#baz,foo:bar")));
+        assertPayload("my.prefix.mydistribution:0.423|d|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -519,7 +535,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordDistributionValue("mydistribution", 0.423, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mydistribution:0.423|d|@1.000000|#baz,foo:bar")));
+        assertPayload("my.prefix.mydistribution:0.423|d|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -529,7 +545,7 @@ public class NonBlockingStatsDClientTest {
         client.recordExecutionTime("mytime", 123);
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mytime:123|ms")));
+        assertPayload("my.prefix.mytime:123|ms");
     }
 
     /**
@@ -551,7 +567,7 @@ public class NonBlockingStatsDClientTest {
             client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mytime:123|ms|#baz,foo:bar")));
+            assertPayload("my.prefix.mytime:123|ms|#baz,foo:bar");
         } finally {
             // reset the default Locale in case changing it has side-effects
             Locale.setDefault(originalDefaultLocale);
@@ -565,7 +581,7 @@ public class NonBlockingStatsDClientTest {
         client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mytime:123|ms|#baz,foo:bar")));
+        assertPayload("my.prefix.mytime:123|ms|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -574,28 +590,7 @@ public class NonBlockingStatsDClientTest {
         clientUnaggregated.recordExecutionTime("mytime", 123, 1, "foo:bar", "baz");
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mytime:123|ms|@1.000000|#baz,foo:bar")));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_mixed_tags_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .constantTags("instance:foo", "app:bar")
-            .originDetectionEnabled(false)
-            .build();
-        try {
-            client.gauge("value", 423, "baz");
-            server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#app:bar,instance:foo,baz")));
-        } finally {
-            client.stop();
-        }
+        assertPayload("my.prefix.mytime:123|ms|@1.000000|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -604,38 +599,18 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .queueSize(Integer.MAX_VALUE)
             .constantTags("instance:foo", "app:bar")
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("value", 423, "baz");
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#app:bar,instance:foo,baz")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_mixed_tags_with_sample_rate_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .constantTags("instance:foo", "app:bar")
-            .originDetectionEnabled(false)
-            .build();
-        try {
-            client.gauge("value", 423, 1, "baz");
-            server.waitForMessage("my.prefix.value:423");
-
-            List<String> messages = server.messagesReceived();
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.value:423|g|@1.000000|#app:bar,instance:foo,baz")));
+            assertPayload("my.prefix.value:423|g|#app:bar,instance:foo,baz");
         } finally {
             client.stop();
         }
@@ -647,38 +622,18 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .queueSize(Integer.MAX_VALUE)
             .constantTags("instance:foo", "app:bar")
             .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("value", 423, 1, "baz");
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|@1.000000|#app:bar,instance:foo,baz")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_constant_tags_only_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .constantTags("instance:foo", "app:bar")
-            .originDetectionEnabled(false)
-            .build();
-        try {
-            client.gauge("value", 423);
-            server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#app:bar,instance:foo")));
+            assertPayload("my.prefix.value:423|g|@1.000000|#app:bar,instance:foo,baz");
         } finally {
             client.stop();
         }
@@ -690,37 +645,18 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .queueSize(Integer.MAX_VALUE)
             .constantTags("instance:foo", "app:bar")
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#app:bar,instance:foo")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_entityID_from_env_deprecated() throws Exception {
-        final String entity_value =  "foo-entity";
-        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .containerID("fake-container-id")
-            .build();
-        try {
-            client.gauge("value", 423);
-            server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
+            assertPayload("my.prefix.value:423|g|#app:bar,instance:foo");
         } finally {
             client.stop();
         }
@@ -733,38 +669,17 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .queueSize(Integer.MAX_VALUE)
-            .containerID("fake-container-id")
+            .containerID(containerID)
+            .enableAggregation(false)
+            .originDetectionEnabled(false)
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage();
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_entityID_from_env_and_constant_tags_deprecated() throws Exception {
-        final String entity_value =  "foo-entity";
-        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
-        final String constantTags = "arbitraryTag:arbitraryValue";
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .constantTags(constantTags)
-            .containerID("fake-container-id")
-            .build();
-        try {
-            client.gauge("value", 423);
-            server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags + "|c:fake-container-id")));
+            assertPayload("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity");
         } finally {
             client.stop();
         }
@@ -778,41 +693,16 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .constantTags(constantTags)
+            .enableAggregation(false)
+            .containerID(containerID)
             .originDetectionEnabled(false)
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags)));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_entityID_from_args_deprecated() throws Exception {
-        final String entity_value =  "foo-entity";
-        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .constantTags(null)
-            .errorHandler(null)
-            .entityID(entity_value+"-arg")
-            .containerID("fake-container-id")
-            .build();
-
-        try {
-            client.gauge("value", 423);
-            server.waitForMessage("my.prefix");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg|c:fake-container-id")));
+            assertPayload("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity," + constantTags);
         } finally {
             client.stop();
         }
@@ -825,16 +715,18 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .queueSize(Integer.MAX_VALUE)
             .entityID(entity_value+"-arg")
-            .containerID("fake-container-id")
+            .containerID(containerID)
+            .enableAggregation(false)
+            .originDetectionEnabled(false)
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg|c:fake-container-id")));
+            assertPayload("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity-arg");
         } finally {
             client.stop();
         }
@@ -843,24 +735,26 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void init_client_from_env_vars() throws Exception {
         final String entity_value = "foo-entity";
-        environmentVariables.set(NonBlockingStatsDClient.DD_DOGSTATSD_PORT_ENV_VAR, Integer.toString(STATSD_SERVER_PORT));
+        environmentVariables.set(NonBlockingStatsDClient.DD_DOGSTATSD_PORT_ENV_VAR, Integer.toString(server.getPort()));
         environmentVariables.set(NonBlockingStatsDClient.DD_AGENT_HOST_ENV_VAR, "localhost");
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g")));
+            assertPayload("my.prefix.value:423|g");
         } finally {
             client.stop();
         }
     }
 
     @Test(timeout = 15000L)
-    public void checkEnvVars() {
+    public void checkEnvVars() throws Exception {
         final Random r = new Random();
         for (final NonBlockingStatsDClient.Literal literal : NonBlockingStatsDClient.Literal.values()) {
             final String envVarName = literal.envName();
@@ -869,41 +763,21 @@ public class NonBlockingStatsDClientTest {
             final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
                     .prefix("checkEnvVars")
                     .hostname("localhost")
-                    .port(STATSD_SERVER_PORT)
+                    .port(server.getPort())
                     .originDetectionEnabled(false)
+                    .aggregationFlushInterval(100)
+                    .containerID(containerID)
                     .build();
             server.clear();
             client.gauge("value", 42);
             server.waitForMessage("checkEnvVars.value");
             log.info("passed for '" + literal + "'; env cleaned.");
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("checkEnvVars.value:42|g|#" +
-                    literal.tag() + ":" + randomString)));
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("checkEnvVars.value:42|g|#" +
-                    envVarName.replace("DD_", "").toLowerCase() + ":" + randomString)));
+            assertPayload("checkEnvVars.value:42|g|#" + literal.tag() + ":" + randomString);
+            assertPayload("checkEnvVars.value:42|g|#" + envVarName.replace("DD_", "").toLowerCase() + ":" + randomString);
             server.clear();
 
             environmentVariables.clear(envVarName);
             log.info("passed for '" + literal + "'; env cleaned.");
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_empty_prefix_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            client.gauge("top.level.value", 423);
-            server.waitForMessage("top.level");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("top.level.value:423|g")));
-        } finally {
             client.stop();
         }
     }
@@ -914,34 +788,16 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("top.level.value", 423);
             server.waitForMessage("top.level");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("top.level.value:423|g")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_null_prefix_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix(null)
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            client.gauge("top.level.value", 423);
-            server.waitForMessage("top.level");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("top.level.value:423|g")));
+            assertPayload("top.level.value:423|g");
         } finally {
             client.stop();
         }
@@ -953,14 +809,16 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix(null)
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             client.gauge("top.level.value", 423);
             server.waitForMessage("top.level");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("top.level.value:423|g")));
+            assertPayload("top.level.value:423|g");
         } finally {
             client.stop();
         }
@@ -971,14 +829,16 @@ public class NonBlockingStatsDClientTest {
 
         final NonBlockingStatsDClient no_prefix_client = new NonBlockingStatsDClientBuilder()
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
         try {
             no_prefix_client.gauge("top.level.value", 423);
             server.waitForMessage("top.level");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("top.level.value:423|g")));
+            assertPayload("top.level.value:423|g");
         } finally {
             no_prefix_client.stop();
         }
@@ -1000,10 +860,7 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event);
         server.waitForMessage();
 
-        assertThat(
-            server.messagesReceived(),
-            hasItem(comparesEqualTo("_e{16,12}:my.prefix.title1|text1\\nline2|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1"))
-        );
+        assertPayload("_e{16,12}:my.prefix.title1|text1\\nline2|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1");
     }
 
     @Test(timeout = 5000L)
@@ -1014,10 +871,7 @@ public class NonBlockingStatsDClientTest {
         assertEquals(event.getText(), "Delivered — destination.csv");
         client.recordEvent(event);
         server.waitForMessage();
-        assertThat(
-            server.messagesReceived(),
-            hasItem(comparesEqualTo("_e{89,29}:my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded|Delivered — destination.csv"))
-        );
+        assertPayload("_e{89,29}:my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded|Delivered — destination.csv");
     }
 
     @Test(timeout = 5000L)
@@ -1031,7 +885,7 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{16,5}:my.prefix.title1|text1|d:1234567")));
+        assertPayload("_e{16,5}:my.prefix.title1|text1|d:1234567");
     }
 
     @Test(timeout = 5000L)
@@ -1050,7 +904,7 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event, "foo:bar", "baz");
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{16,5}:my.prefix.title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar")));
+        assertPayload("_e{16,5}:my.prefix.title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -1064,36 +918,7 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event, "foo:bar", "baz");
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{16,5}:my.prefix.title1|text1|d:1234567|#baz,foo:bar")));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_event_empty_prefix_deprecated() throws Exception {
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .originDetectionEnabled(false)
-            .build();
-        final Event event = Event.builder()
-                .withTitle("title1")
-                .withText("text1")
-                .withDate(1234567000)
-                .withHostname("host1")
-                .withPriority(Event.Priority.LOW)
-                .withAggregationKey("key1")
-                .withAlertType(Event.AlertType.ERROR)
-                .withSourceTypeName("sourcetype1")
-                .build();
-        try {
-            client.recordEvent(event, "foo:bar", "baz");
-            server.waitForMessage("_e");
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{6,5}:title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar")));
-        } finally {
-            client.stop();
-        }
+        assertPayload("_e{16,5}:my.prefix.title1|text1|d:1234567|#baz,foo:bar");
     }
 
     @Test(timeout = 5000L)
@@ -1102,8 +927,10 @@ public class NonBlockingStatsDClientTest {
         final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
             .prefix("")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
 
         final Event event = Event.builder()
@@ -1120,7 +947,7 @@ public class NonBlockingStatsDClientTest {
             client.recordEvent(event, "foo:bar", "baz");
             server.waitForMessage("_e");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{6,5}:title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar")));
+            assertPayload("_e{6,5}:title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|#baz,foo:bar");
         } finally {
             client.stop();
         }
@@ -1135,7 +962,7 @@ public class NonBlockingStatsDClientTest {
         client.recordEvent(event);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("_e{15,0}:my.prefix.title||d:1234567")));
+        assertPayload("_e{15,0}:my.prefix.title||d:1234567");
     }
 
     @Test(timeout = 5000L)
@@ -1157,8 +984,7 @@ public class NonBlockingStatsDClientTest {
         client.serviceCheck(sc);
         server.waitForMessage("_sc");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s",
-                outputMessage))));
+        assertPayload(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s", outputMessage));
     }
 
     @Test(timeout = 5000L)
@@ -1167,7 +993,7 @@ public class NonBlockingStatsDClientTest {
 
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.mygauge:NaN|g")));
+        assertPayload("my.prefix.mygauge:NaN|g");
     }
 
     @Test(timeout = 5000L)
@@ -1176,7 +1002,7 @@ public class NonBlockingStatsDClientTest {
 
         server.waitForMessage("my.prefix");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myset:myuserid|s")));
+        assertPayload("my.prefix.myset:myuserid|s");
 
     }
 
@@ -1186,48 +1012,8 @@ public class NonBlockingStatsDClientTest {
 
         server.waitForMessage("my.prefix.myset");
 
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myset:myuserid|s|#baz,foo:bar")));
+        assertPayload("my.prefix.myset:myuserid|s|#baz,foo:bar");
 
-    }
-
-    @Test(timeout=5000L)
-    public void sends_too_large_message_deprecated() throws Exception {
-
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-
-        try (final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build()) {
-
-            final byte[] messageBytes = new byte[1600];
-            final ServiceCheck tooLongServiceCheck = ServiceCheck.builder()
-                    .withName("toolong")
-                    .withMessage(new String(messageBytes))
-                    .withStatus(ServiceCheck.Status.OK)
-                    .build();
-            testClient.serviceCheck(tooLongServiceCheck);
-
-            final ServiceCheck withinLimitServiceCheck = ServiceCheck.builder()
-                    .withName("fine")
-                    .withStatus(ServiceCheck.Status.OK)
-                    .build();
-            testClient.serviceCheck(withinLimitServiceCheck);
-
-            server.waitForMessage("_sc");
-
-            final List<Exception> exceptions = errorHandler.getExceptions();
-            assertEquals(1, exceptions.size());
-            final Exception exception = exceptions.get(0);
-            assertEquals(InvalidMessageException.class, exception.getClass());
-            assertTrue(((InvalidMessageException)exception).getInvalidMessage().startsWith("_sc|toolong|"));
-
-            final List<String> messages = server.messagesReceived();
-            assertThat(messages, hasItem(comparesEqualTo("_sc|fine|0")));
-        }
     }
 
     @Test(timeout=5000L)
@@ -1238,9 +1024,11 @@ public class NonBlockingStatsDClientTest {
         try (final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
                 .prefix("my.prefix")
                 .hostname("localhost")
-                .port(STATSD_SERVER_PORT)
+                .port(server.getPort())
                 .errorHandler(errorHandler)
+                .enableAggregation(false)
                 .originDetectionEnabled(false)
+                .containerID(containerID)
                 .build()) {
 
             final byte[] messageBytes = new byte[1600];
@@ -1266,31 +1054,32 @@ public class NonBlockingStatsDClientTest {
             assertTrue(((InvalidMessageException)exception).getInvalidMessage().startsWith("_sc|toolong|"));
             // assertEquals(BufferOverflowException.class, exception.getClass());
 
-            final List<String> messages = server.messagesReceived();
-            assertThat(messages, hasItem(comparesEqualTo("_sc|fine|0")));
+            assertPayload("_sc|fine|0");
         }
     }
 
     @Test(timeout=5000L)
     public void sends_telemetry_elsewhere() throws Exception {
         final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final DummyStatsDServer telemetryServer = new UDPDummyStatsDServer(STATSD_SERVER_PORT+10);
+        final UDPDummyStatsDServer telemetryServer = new UDPDummyStatsDServer(0);
         final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
             .prefix("my.prefix")
             .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
+            .port(server.getPort())
             .telemetryHostname("localhost")
-            .telemetryPort(STATSD_SERVER_PORT+10)
-            .telemetryFlushInterval(3000)
+            .telemetryPort(telemetryServer.getPort())
+            .telemetryFlushInterval(500)
             .errorHandler(errorHandler)
+            .enableAggregation(false)
             .originDetectionEnabled(false)
+            .containerID(containerID)
             .build();
 
         try {
             testClient.gauge("top.level.value", 423);
             server.waitForMessage("my.prefix");
 
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.top.level.value:423|g")));
+            assertPayload("my.prefix.top.level.value:423|g");
 
             telemetryServer.waitForMessage();
 
@@ -1300,7 +1089,7 @@ public class NonBlockingStatsDClientTest {
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.metrics:1|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.events:0|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.service_checks:0|c")));
-            assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.bytes_sent:32|c")));
+            assertThat(messages, hasItem(startsWith(String.format("datadog.dogstatsd.client.bytes_sent:%d|c", 32 + payloadTail.length()))));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.bytes_dropped:0|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.packets_sent:1|c")));
             assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.packets_dropped:0|c")));
@@ -1309,209 +1098,6 @@ public class NonBlockingStatsDClientTest {
         } finally {
             testClient.stop();
             telemetryServer.close();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testBasicGaugeAggregation() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)  // don't want additional packets
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            for (int i=0 ; i<10 ; i++) {
-                testClient.gauge("top.level.value", i);
-            }
-            server.waitForMessage("my.prefix");
-
-            List<String> messages = server.messagesReceived();
-
-            assertThat(messages.size(), comparesEqualTo(1));
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.value:9|g")));
-
-        } finally {
-            testClient.stop();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testBasicCountAggregation() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)  // don't want additional packets
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            for (int i=0 ; i<10 ; i++) {
-                testClient.count("top.level.count", i);
-            }
-            for (int i=0 ; i<10 ; i++) {
-                testClient.increment("top.level.count");
-            }
-
-            server.waitForMessage("my.prefix");
-
-            List<String> messages = server.messagesReceived();
-
-            assertThat(messages.size(), comparesEqualTo(1));
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.count:55|c")));
-
-        } finally {
-            testClient.stop();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testSampledCountAggregation() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)  // don't want additional packets
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            for (int i=0 ; i<10 ; i++) {
-                // NOTE: because aggregation is enabled, sampling is disabled, so all
-                // counts should be accounted for, as if sample rate were 1.0.
-                testClient.count("top.level.count", i, 0.1);
-            }
-            for (int i=0 ; i<10 ; i++) {
-                testClient.increment("top.level.count");
-            }
-
-            server.waitForMessage("my.prefix");
-
-            List<String> messages = server.messagesReceived();
-
-            assertThat(messages.size(), comparesEqualTo(1));
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.count:55|c")));
-
-        } finally {
-            testClient.stop();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testBasicSetAggregation() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)  // don't want additional packets
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            for (int i=0 ; i<10 ; i++) {
-                testClient.recordSetValue("top.level.set", "foo", null);
-                testClient.recordSetValue("top.level.set", "bar", null);
-            }
-
-            server.waitForMessage("my.prefix");
-
-            List<String> messages = server.messagesReceived();
-
-            assertThat(messages.size(), comparesEqualTo(2));
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.set:foo|s")));
-            assertThat(messages, hasItem(comparesEqualTo("my.prefix.top.level.set:bar|s")));
-
-        } finally {
-            testClient.stop();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testAggregationTelemetry() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .telemetryFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            for (int i=0 ; i<10 ; i++) {
-                testClient.gauge("top.level.value", i);
-            }
-            for (int i=0 ; i<10 ; i++) {
-                testClient.count("top.level.count", i);
-            }
-            for (int i=0 ; i<10 ; i++) {
-                testClient.increment("top.level.count.other");
-            }
-
-            server.waitForMessage("datadog");
-
-            List<String> messages = server.messagesReceived();
-
-            assertThat(messages.size(), comparesEqualTo(3+17));
-            assertThat(messages, hasItem(startsWith("datadog.dogstatsd.client.aggregated_context:27|c")));
-
-        } finally {
-            testClient.stop();
-        }
-    }
-
-    @Test(timeout=5000L)
-    public void testBasicUnaggregatedMetrics() throws Exception {
-        final RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        final NonBlockingStatsDClient testClient = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)  // don't want additional packets
-            .enableAggregation(true)
-            .aggregationFlushInterval(3000)
-            .errorHandler(errorHandler)
-            .originDetectionEnabled(false)
-            .build();
-
-        try {
-            int submitted = 0;
-            for (int i=0 ; i<10 ; i++) {
-                testClient.histogram("top.level.hist", i);
-                testClient.distribution("top.level.dist", i);
-                testClient.time("top.level.time", i);
-                submitted += 3;
-            }
-            server.waitForMessage("my.prefix");
-
-            List<String> messages = server.messagesReceived();
-
-            // there should be one message per
-            assertThat(messages.size(), comparesEqualTo(submitted));
-
-        } finally {
-            testClient.stop();
         }
     }
 
@@ -1578,6 +1164,7 @@ public class NonBlockingStatsDClientTest {
 
         final NonBlockingStatsDClientBuilder builder = new SlowStatsDNonBlockingStatsDClientBuilder().prefix("")
             .hostname("localhost")
+            .aggregationFlushInterval(100)
             .originDetectionEnabled(false)
             .port(port);
         final SlowStatsDNonBlockingStatsDClient client = ((SlowStatsDNonBlockingStatsDClientBuilder)builder).build();
@@ -1592,159 +1179,6 @@ public class NonBlockingStatsDClientTest {
             server.close();
             assertEquals(0, client.getLock().getCount());
         }
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_gauge_with_containerID() throws Exception {
-        clientWithContainerID.gauge("value", 423, "foo");
-        server.waitForMessage("my.prefix");
-
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#foo|c:fake-container-id")));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_counter_with_containerID() throws Exception {
-        clientWithContainerID.count("value", 423, "foo");
-        server.waitForMessage("my.prefix");
-
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|c|#foo|c:fake-container-id")));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_set_with_containerID() throws Exception {
-        clientWithContainerID.recordSetValue("myset", "myuserid", "foo");
-        server.waitForMessage("my.prefix.myset");
-
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.myset:myuserid|s|#foo|c:fake-container-id")));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_service_check_with_containerID() throws Exception {
-        final String inputMessage = "\u266c \u2020\u00f8U \n\u2020\u00f8U \u00a5\u00bau|m: T0\u00b5 \u266a"; // "♬ †øU \n†øU ¥ºu|m: T0µ ♪"
-        final String outputMessage = "\u266c \u2020\u00f8U \\n\u2020\u00f8U \u00a5\u00bau|m\\: T0\u00b5 \u266a"; // note the escaped colon
-        final String[] tags = {"key1:val1", "key2:val2"};
-        final ServiceCheck sc = ServiceCheck.builder()
-                .withName("my_check.name")
-                .withStatus(ServiceCheck.Status.WARNING)
-                .withMessage(inputMessage)
-                .withHostname("i-abcd1234")
-                .withTags(tags)
-                .withTimestamp(1420740000)
-                .build();
-
-        assertEquals(outputMessage, sc.getEscapedMessage());
-
-        clientWithContainerID.serviceCheck(sc);
-        server.waitForMessage("_sc");
-
-        assertThat(server.messagesReceived(), hasItem(comparesEqualTo(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s|c:fake-container-id",
-                outputMessage))));
-    }
-
-    @Test(timeout = 5000L)
-    public void sends_event_with_containerID() throws Exception {
-
-        final Event event = Event.builder()
-                .withTitle("title1")
-                .withText("text1\nline2")
-                .withDate(1234567000)
-                .withHostname("host1")
-                .withPriority(Event.Priority.LOW)
-                .withAggregationKey("key1")
-                .withAlertType(Event.AlertType.ERROR)
-                .withSourceTypeName("sourcetype1")
-                .build();
-
-        clientWithContainerID.recordEvent(event);
-        server.waitForMessage();
-
-        assertThat(
-            server.messagesReceived(),
-            hasItem(comparesEqualTo("_e{16,12}:my.prefix.title1|text1\\nline2|d:1234567|h:host1|k:key1|p:low|t:error|s:sourcetype1|c:fake-container-id"))
-        );
-    }
-
-    @Test(timeout = 5000L)
-    public void test_entity_id_and_container_id() throws Exception {
-        final String entity_value = "foo-entity";
-        environmentVariables.set(NonBlockingStatsDClient.DD_ENTITY_ID_ENV_VAR, entity_value);
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .enableTelemetry(false)
-            .containerID("fake-container-id")
-            .build();
-        try {
-            client.gauge("value", 423);
-            server.waitForMessage();
-
-            assertThat(server.messagesReceived(), hasItem(comparesEqualTo("my.prefix.value:423|g|#dd.internal.entity_id:foo-entity|c:fake-container-id")));
-        } finally {
-            client.stop();
-        }
-    }
-
-    @Test(timeout = 5000L)
-    public void origin_detection_env_false() throws Exception {
-        environmentVariables.set(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR, "false");
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .errorHandler(null)
-            .enableTelemetry(false)
-            .build();
-
-        assertFalse(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
-        environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
-    }
-
-    @Test(timeout = 5000L)
-    public void origin_detection_env_unknown() throws Exception {
-        environmentVariables.set(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR, "unknown"); // default to true
-
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .errorHandler(null)
-            .enableTelemetry(false)
-            .build();
-
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
-        environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
-    }
-
-    @Test(timeout = 5000L)
-    public void origin_detection_env_unset() throws Exception {
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .errorHandler(null)
-            .enableTelemetry(false)
-            .build();
-
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
-    }
-
-    @Test(timeout = 5000L)
-    public void origin_detection_arg_false() throws Exception {
-        final NonBlockingStatsDClient client = new NonBlockingStatsDClientBuilder()
-            .prefix("my.prefix")
-            .hostname("localhost")
-            .port(STATSD_SERVER_PORT)
-            .queueSize(Integer.MAX_VALUE)
-            .errorHandler(null)
-            .enableTelemetry(false)
-            .build();
-
-        assertFalse(client.isOriginDetectionEnabled(null, false));
     }
 
     private static class SlowStatsDNonBlockingStatsDClient extends NonBlockingStatsDClient {
@@ -1796,14 +1230,13 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout = 5000L)
     public void nonsampling_client_test() throws Exception {
-        final int port = 17256;
-        final DummyStatsDServer server = new UDPDummyStatsDServer(port);
-
 	final NonBlockingStatsDClientBuilder builder = new NonsamplingClientBuilder()
 	    .prefix("")
             .hostname("localhost")
-        .originDetectionEnabled(false)
-	    .port(port);
+            .enableAggregation(false)
+            .originDetectionEnabled(false)
+            .containerID(containerID)
+	    .port(server.getPort());
 
 	final NonsamplingClient client = ((NonsamplingClientBuilder)builder).build();
 
@@ -1812,10 +1245,9 @@ public class NonBlockingStatsDClientTest {
 	    server.waitForMessage();
 	    List<String> messages = server.messagesReceived();
             assertEquals(1, messages.size());
-            assertEquals(messages.get(0), "test.gauge:42|g|@0.000000");
+            assertPayload("test.gauge:42|g|@0.000000");
         } finally {
             client.stop();
-            server.close();
         }
     }
 
@@ -1824,7 +1256,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void blocking_close_test() throws Exception {
         final int port = 17256;
-        final byte[] expect = "test:1|g\n".getBytes(StandardCharsets.UTF_8);
+        final byte[] expect = ("test:1|g" + payloadTail + "\n").getBytes(StandardCharsets.UTF_8);
         NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder() {
                 @Override
                 public NonBlockingStatsDClient build() {
@@ -1852,7 +1284,7 @@ public class NonBlockingStatsDClientTest {
                     };
                 }
             };
-        NonBlockingStatsDClient client = builder.hostname("localhost").port(port).blocking(true).build();
+        NonBlockingStatsDClient client = builder.hostname("localhost").port(port).blocking(true).containerID(containerID).build();
         client.gauge("test", 1);
         client.close();
         assertEquals(true, blocking_close_sent);
@@ -1866,6 +1298,7 @@ public class NonBlockingStatsDClientTest {
         NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder() {
                 @Override
                 public NonBlockingStatsDClient build() {
+                    this.enableAggregation(false);
                     this.originDetectionEnabled(false);
                     this.bufferPoolSize(1);
                     return new NonBlockingStatsDClient(resolve()) {
@@ -1912,15 +1345,5 @@ public class NonBlockingStatsDClientTest {
         client.stop();
 
         assertEquals(0, errors.size());
-    }
-
-    @Test(timeout = 5000L)
-    public void address_resolution_empty() throws Exception {
-        assertThrows(StatsDClientException.class, new ThrowingRunnable() {
-                @Override
-                public void run() {
-                    new NonBlockingStatsDClientBuilder().resolve();
-                }
-            });
     }
 }


### PR DESCRIPTION
No functional changes, only refactoring tests. Split some tests into separate classes, remove obsolete ones, and unify containerID-specific tests with the rest of the test cases.