### PR TITLE
AGTMETRICS-212 simplify origin detection logic

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -227,9 +227,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
                         costantPreTags.toArray(new String[costantPreTags.size()]), null, new StringBuilder()).toString();
             }
             costantPreTags = null;
-            // Origin detection
-            boolean originEnabled = isOriginDetectionEnabled(builder.containerID, builder.originDetectionEnabled);
-            containerID = getContainerID(builder.containerID, originEnabled);
+            containerID = getContainerID(builder.containerID, builder.originDetectionEnabled);
         }
 
         try {
@@ -1211,8 +1209,8 @@ public class NonBlockingStatsDClient implements StatsDClient {
         return sampleRate != 1 && ThreadLocalRandom.current().nextDouble() > sampleRate;
     }
 
-    boolean isOriginDetectionEnabled(String containerID, boolean originDetectionEnabled) {
-        if (!originDetectionEnabled || (containerID != null && !containerID.isEmpty())) {
+    boolean isOriginDetectionEnabled(boolean originDetectionEnabled) {
+        if (!originDetectionEnabled) {
             // origin detection is explicitly disabled
             // or a user-defined container ID was provided
             return false;
@@ -1234,7 +1232,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
             return containerID;
         }
 
-        if (originDetectionEnabled) {
+        if (isOriginDetectionEnabled(originDetectionEnabled)) {
             CgroupReader reader = new CgroupReader();
             try {
                 return reader.getContainerID();

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientBuilderTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientBuilderTest.java
@@ -26,7 +26,7 @@ public class NonBlockingStatsDClientBuilderTest {
             .enableTelemetry(false)
             .build();
 
-        assertFalse(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+        assertFalse(client.isOriginDetectionEnabled(NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
         environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
     }
 
@@ -44,7 +44,7 @@ public class NonBlockingStatsDClientBuilderTest {
             .enableTelemetry(false)
             .build();
 
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+        assertTrue(client.isOriginDetectionEnabled(NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
         environmentVariables.clear(NonBlockingStatsDClient.ORIGIN_DETECTION_ENABLED_ENV_VAR);
     }
 
@@ -60,7 +60,7 @@ public class NonBlockingStatsDClientBuilderTest {
             .enableTelemetry(false)
             .build();
 
-        assertTrue(client.isOriginDetectionEnabled(null, NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
+        assertTrue(client.isOriginDetectionEnabled(NonBlockingStatsDClient.DEFAULT_ENABLE_ORIGIN_DETECTION));
     }
 
     @Test(timeout = 5000L)
@@ -74,7 +74,7 @@ public class NonBlockingStatsDClientBuilderTest {
             .enableTelemetry(false)
             .build();
 
-        assertFalse(client.isOriginDetectionEnabled(null, false));
+        assertFalse(client.isOriginDetectionEnabled(false));
     }
 
     @Test(timeout = 5000L)


### PR DESCRIPTION
originDetectionEnabled is used to determine when to try to read container information from /proc. By that time it is already established that user did not provide a containerID explicitly, so the containerID part of the isOriginEnabled condition is always false.