### PR TITLE
Use ArrayBlockingQueue in StatsDNonBlockingProcessor

### DIFF
--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -1,21 +1,18 @@
 package com.timgroup.statsd;
 
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class StatsDNonBlockingProcessor extends StatsDProcessor {
 
     private final Queue<Message> messages;
-    private final AtomicInteger qsize; // qSize will not reflect actual size, but a close estimate.
 
     private class ProcessingTask extends StatsDProcessor.ProcessingTask {
         @Override
         protected Message getMessage() throws InterruptedException {
             final Message message = messages.poll();
             if (message != null) {
-                qsize.decrementAndGet();
                 return message;
             }
 
@@ -50,8 +47,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                 aggregatorFlushInterval,
                 aggregatorShards,
                 threadFactory);
-        this.qsize = new AtomicInteger(0);
-        this.messages = new ConcurrentLinkedQueue<>();
+        this.messages = new ArrayBlockingQueue<>(qcapacity);
     }
 
     @Override
@@ -62,11 +58,7 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
     @Override
     protected boolean send(final Message message) {
         if (!shutdown) {
-            if (qsize.get() < qcapacity) {
-                messages.offer(message);
-                qsize.incrementAndGet();
-                return true;
-            }
+            return messages.offer(message);
         }
 
         return false;

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -53,7 +53,6 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
         } else {
             this.messages = new LinkedBlockingQueue<>(qcapacity);
         }
-
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
+++ b/src/main/java/com/timgroup/statsd/StatsDNonBlockingProcessor.java
@@ -2,6 +2,7 @@ package com.timgroup.statsd;
 
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 
 public class StatsDNonBlockingProcessor extends StatsDProcessor {
@@ -47,7 +48,12 @@ public class StatsDNonBlockingProcessor extends StatsDProcessor {
                 aggregatorFlushInterval,
                 aggregatorShards,
                 threadFactory);
-        this.messages = new ArrayBlockingQueue<>(qcapacity);
+        if (qcapacity <= 8192) {
+            this.messages = new ArrayBlockingQueue<>(qcapacity);
+        } else {
+            this.messages = new LinkedBlockingQueue<>(qcapacity);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Swaps out the ConcurrentLinkedQueue for ArrayBlockingQueue which is bounded by default removing the need to track queue size independently and avoiding allocation of linked nodes, instead preferring a constant upfront allocation reducing GC churn.

Addresses #287 