### PR TITLE
Use default format for metric values

### DIFF
--- a/src/benchmark/java/com/timgroup/statsd/FullPrecisionBenchmark.java
+++ b/src/benchmark/java/com/timgroup/statsd/FullPrecisionBenchmark.java
@@ -1,0 +1,41 @@
+package com.timgroup.statsd;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class FullPrecisionBenchmark {
+
+    @Param({"3.141592653589793", "3.3E20", "42.0", "0.423", "243.5"})
+    public double value;
+
+    private final StringBuilder builder = new StringBuilder(64);
+
+    @Benchmark
+    public int format_default() {
+        builder.setLength(0);
+        builder.append(NonBlockingStatsDClient.format(NonBlockingStatsDClient.NUMBER_FORMATTER, value));
+        return builder.length();
+    }
+
+    @Benchmark
+    public int format_full_precision() {
+        builder.setLength(0);
+        builder.append(value);
+        return builder.length();
+    }
+}

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -182,6 +182,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
     private final String containerID;
     private final String externalEnv;
     final TagsCardinality clientTagsCardinality;
+    private final boolean fullPrecision;
 
     /**
      * Create a new StatsD client communicating with a StatsD instance on the host and port
@@ -207,6 +208,7 @@ public class NonBlockingStatsDClient implements StatsDClient {
         }
 
         blocking = builder.blocking;
+        fullPrecision = builder.fullPrecision;
         maxPacketSizeBytes = builder.maxPacketSizeBytes;
         clientTagsCardinality = builder.tagsCardinality;
 
@@ -625,7 +627,11 @@ public class NonBlockingStatsDClient implements StatsDClient {
                             tags) {
                         @Override
                         protected void writeValue(StringBuilder builder) {
-                            builder.append(format(NUMBER_FORMATTER, this.value));
+                            if (fullPrecision) {
+                                builder.append(this.value);
+                            } else {
+                                builder.append(format(NUMBER_FORMATTER, this.value));
+                            }
                         }
                     });
         }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -52,6 +52,9 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
 
     public boolean enableAggregation = NonBlockingStatsDClient.DEFAULT_ENABLE_AGGREGATION;
 
+    /** Use full precision when formatting numeric metric values. */
+    public boolean fullPrecision = true;
+
     /** Telemetry flush interval, in milliseconds. */
     public int telemetryFlushInterval = Telemetry.DEFAULT_FLUSH_INTERVAL;
 
@@ -267,6 +270,12 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
 
     public NonBlockingStatsDClientBuilder enableAggregation(boolean val) {
         enableAggregation = val;
+        return this;
+    }
+
+    /** Use full precision when formatting numeric metric values. */
+    public NonBlockingStatsDClientBuilder fullPrecision(boolean val) {
+        fullPrecision = val;
         return this;
     }
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -43,6 +43,7 @@ public class NonBlockingStatsDClientTest {
     private static final int STATSD_SERVER_PORT = 17254;
     private NonBlockingStatsDClient client;
     private NonBlockingStatsDClient clientUnaggregated;
+    private NonBlockingStatsDClient clientFullPrecision;
     private static UDPDummyStatsDServer server;
 
     private static Logger log = Logger.getLogger("NonBlockingStatsDClientTest");
@@ -111,8 +112,20 @@ public class NonBlockingStatsDClientTest {
                         .originDetectionEnabled(originDetectionEnabled)
                         .aggregationFlushInterval(100)
                         .containerID(containerID)
+                        .fullPrecision(false)
                         .build();
         clientUnaggregated =
+                new NonBlockingStatsDClientBuilder()
+                        .prefix("my.prefix")
+                        .hostname("localhost")
+                        .port(server.getPort())
+                        .enableTelemetry(false)
+                        .enableAggregation(false)
+                        .originDetectionEnabled(originDetectionEnabled)
+                        .containerID(containerID)
+                        .fullPrecision(false)
+                        .build();
+        clientFullPrecision =
                 new NonBlockingStatsDClientBuilder()
                         .prefix("my.prefix")
                         .hostname("localhost")
@@ -128,6 +141,7 @@ public class NonBlockingStatsDClientTest {
     public void stop() throws IOException {
         client.stop();
         clientUnaggregated.stop();
+        clientFullPrecision.stop();
         server.close();
     }
 
@@ -234,6 +248,22 @@ public class NonBlockingStatsDClientTest {
 
         assertPayload("my.prefix.mycount:24.5|c|T1|#baz,foo:bar");
         assertPayload("my.prefix.mycount:42.5|c|T1|#baz,foo:bar");
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_large_long_counter_to_statsd() throws Exception {
+        clientUnaggregated.count("mycount", 1L << 62);
+        server.waitForMessage("my.prefix");
+
+        assertPayload("my.prefix.mycount:4611686018427387904|c");
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_large_long_counter_to_statsd_with_full_precision() throws Exception {
+        clientFullPrecision.count("mycount", 1L << 62);
+        server.waitForMessage("my.prefix");
+
+        assertPayload("my.prefix.mycount:4611686018427387904|c");
     }
 
     @Test(timeout = 5000L)
@@ -354,10 +384,19 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout = 5000L)
     public void sends_large_double_gauge_to_statsd() throws Exception {
 
-        client.recordGaugeValue("mygauge", 123456789012345.67890);
+        client.recordGaugeValue("mygauge", 3.3e20);
         server.waitForMessage("my.prefix");
 
-        assertPayload("my.prefix.mygauge:123456789012345.67|g");
+        assertPayload("my.prefix.mygauge:330000000000000000000|g");
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_large_double_gauge_to_statsd_with_full_precision() throws Exception {
+
+        clientFullPrecision.recordGaugeValue("mygauge", 3.3e20);
+        server.waitForMessage("my.prefix");
+
+        assertPayload("my.prefix.mygauge:3.3E20|g");
     }
 
     @Test(timeout = 5000L)
@@ -394,6 +433,20 @@ public class NonBlockingStatsDClientTest {
         server.waitForMessage("my.prefix");
 
         assertPayload("my.prefix.mygauge:423|g|@1.000000|#baz,foo:bar");
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_with_full_precision_to_statsd() throws Exception {
+        clientFullPrecision.recordGaugeValue("mygauge", Math.PI);
+        server.waitForMessage("my.prefix");
+        assertPayload("my.prefix.mygauge:3.141592653589793|g");
+    }
+
+    @Test(timeout = 5000L)
+    public void sends_gauge_with_full_precision_integer_value_to_statsd() throws Exception {
+        clientFullPrecision.recordGaugeValue("mygauge", 42.0);
+        server.waitForMessage("my.prefix");
+        assertPayload("my.prefix.mygauge:42.0|g");
     }
 
     @Test(timeout = 5000L)


### PR DESCRIPTION
Numeric metric values were formatted using specialized number format that truncated values to 6 fractional digits and did not use exponential format for larger numbers. While it slightly reduces number of transmitted bytes for fractional numbers close zero, it is less efficient for larger values.

A micro-benchmark also shows that not using NumberFormat is generally much faster. These numbers are from JDK 11, but the numbers are similar for JDK 8 and 25.

```
Benchmark                                               (value)   Mode  Cnt   Score   Error   Units
FullPrecisionBenchmark.format_default         3.141592653589793  thrpt   10   3.035 ± 0.182  ops/us
FullPrecisionBenchmark.format_default                    3.3E20  thrpt   10   3.465 ± 0.764  ops/us
FullPrecisionBenchmark.format_default                      42.0  thrpt   10   5.711 ± 1.908  ops/us
FullPrecisionBenchmark.format_default                     0.423  thrpt   10   4.977 ± 1.437  ops/us
FullPrecisionBenchmark.format_default                     243.5  thrpt   10   4.871 ± 0.232  ops/us
FullPrecisionBenchmark.format_full_precision  3.141592653589793  thrpt   10   5.888 ± 0.411  ops/us
FullPrecisionBenchmark.format_full_precision             3.3E20  thrpt   10  20.946 ± 0.681  ops/us
FullPrecisionBenchmark.format_full_precision               42.0  thrpt   10  33.849 ± 0.391  ops/us
FullPrecisionBenchmark.format_full_precision              0.423  thrpt   10  23.927 ± 0.685  ops/us
FullPrecisionBenchmark.format_full_precision              243.5  thrpt   10  16.318 ± 0.777  ops/us
```

This brings brings client behavior closer to that of other clients: Python uses built-in `str()` conversion which will use exponential format for large numbers, and Go, which, while doesn't use exponential format, does not truncate precision (on most metrics at least).

All agent versions and ADP/Saluki are able to handle this format. An option is added to restore legacy behavior in case this causes any compatibility issues.