### PR TITLE
Do not encode sketch summary value

### DIFF
--- a/dogstatsd-http-serializer/src/main/java/com/datadoghq/dogstatsd/http/serializer/SketchMetric.java
+++ b/dogstatsd-http-serializer/src/main/java/com/datadoghq/dogstatsd/http/serializer/SketchMetric.java
@@ -9,7 +9,6 @@ package com.datadoghq.dogstatsd.http.serializer;
 
 /** Builder for sketch timeseries. */
 public class SketchMetric extends Metric<SketchMetric> {
-    private static final int VALUES_PER_SKETCH_POINT = 4;
 
     SketchMetric(PayloadBuilder pb, int type, String name) {
         super(pb, type, name);
@@ -25,7 +24,6 @@ public class SketchMetric extends Metric<SketchMetric> {
      *
      * @param timestamp Timestamp of the point in seconds since Unix epoch.
      * @param sum Total sum of all observed values.
-     * @param avg Average of all observed values.
      * @param min Minimum observed value.
      * @param max Maximum observed value.
      * @param cnt Number of observed values.
@@ -36,7 +34,6 @@ public class SketchMetric extends Metric<SketchMetric> {
     public SketchMetric addPoint(
             long timestamp,
             double sum,
-            double avg,
             double min,
             double max,
             long cnt,
@@ -49,7 +46,6 @@ public class SketchMetric extends Metric<SketchMetric> {
 
         pb.timestamps.put(timestamp);
         pb.values.put(sum);
-        pb.values.put(avg);
         pb.values.put(min);
         pb.values.put(max);
         pb.counts.put(cnt);
@@ -65,6 +61,8 @@ public class SketchMetric extends Metric<SketchMetric> {
 
         return this;
     }
+
+    private static final int VALUES_PER_SKETCH_POINT = 3;
 
     @Override
     void encodeValues(ValueType valueType) {
@@ -88,9 +86,6 @@ public class SketchMetric extends Metric<SketchMetric> {
                     r.putSint64(
                             Column.valsSint64,
                             (long) pb.values.get(VALUES_PER_SKETCH_POINT * i + 2));
-                    r.putSint64(
-                            Column.valsSint64,
-                            (long) pb.values.get(VALUES_PER_SKETCH_POINT * i + 3));
                     r.putSint64(Column.valsSint64, pb.counts.get(i));
                 }
                 break;
@@ -104,9 +99,6 @@ public class SketchMetric extends Metric<SketchMetric> {
                     r.putFloat32(
                             Column.valsFloat32,
                             (float) pb.values.get(VALUES_PER_SKETCH_POINT * i + 2));
-                    r.putFloat32(
-                            Column.valsFloat32,
-                            (float) pb.values.get(VALUES_PER_SKETCH_POINT * i + 3));
                     r.putSint64(Column.valsSint64, pb.counts.get(i));
                 }
                 break;
@@ -117,8 +109,6 @@ public class SketchMetric extends Metric<SketchMetric> {
                             Column.valsFloat64, pb.values.get(VALUES_PER_SKETCH_POINT * i + 1));
                     r.putFloat64(
                             Column.valsFloat64, pb.values.get(VALUES_PER_SKETCH_POINT * i + 2));
-                    r.putFloat64(
-                            Column.valsFloat64, pb.values.get(VALUES_PER_SKETCH_POINT * i + 3));
                     r.putSint64(Column.valsSint64, pb.counts.get(i));
                 }
                 break;

--- a/dogstatsd-http-serializer/src/test/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilderTest.java
+++ b/dogstatsd-http-serializer/src/test/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilderTest.java
@@ -44,8 +44,8 @@ public class PayloadBuilderTest {
 
         b.sketch("ijk")
                 .setTags(Arrays.asList(new String[] {"foo", "baz"}))
-                .addPoint(100, 4.75, 2.25, 1.25, 1.75, 3, new int[] {1351, 1373}, new int[] {1, 2})
-                .addPoint(110, 6.5, 3.5, 2.25, 2.75, 5, new int[] {1389, 1402}, new int[] {2, 3})
+                .addPoint(100, 4.75, 1.25, 1.75, 3, new int[] {1351, 1373}, new int[] {1, 2})
+                .addPoint(110, 6.5, 2.25, 2.75, 5, new int[] {1389, 1402}, new int[] {2, 3})
                 .close();
 
         b.rate("lm").setInterval(10).addPoint(100, 3.14).close();
@@ -60,7 +60,7 @@ public class PayloadBuilderTest {
                 new int[] {
                     // MetricData
                     (3 << 3) | 2,
-                    196,
+                    188,
                     1,
                     // dictNameStr
                     (1 << 3) | 2,
@@ -195,17 +195,13 @@ public class PayloadBuilderTest {
                     6,
                     10,
                     // valsFloat32,
-                    // list(pack('<ffffffff', 4.75, 2.25, 1.25, 1.75, 6.5, 3.5, 2.25, 2.75))
+                    // list(pack('<ffffff', 4.75, 1.25, 1.75, 6.5, 2.25, 2.75))
                     (18 << 3) | 2,
                     1,
-                    32,
+                    24,
                     0,
                     0,
                     152,
-                    64,
-                    0,
-                    0,
-                    16,
                     64,
                     0,
                     0,
@@ -218,10 +214,6 @@ public class PayloadBuilderTest {
                     0,
                     0,
                     208,
-                    64,
-                    0,
-                    0,
-                    96,
                     64,
                     0,
                     0,


### PR DESCRIPTION
We do not need to transmit sketch average values, since backend ignores them anyway.