### PR TITLE
AGTMETRICS-489 Add telemetry to dogstatsd-http-forwarder

### DIFF
--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
@@ -12,25 +12,29 @@ import java.util.TreeMap;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 class BoundedQueue {
-    // Key represents a tuple of integers (tries, clock).
+    // Key represents a tuple of integers (tries, clock). enqueuedAtNanos records when the
+    // payload first entered the queue (in System.nanoTime() units) and is preserved across
+    // requeues so that "age of oldest item" remains accurate after retries.
     static class Key implements Comparable<Key> {
         final long tries;
         final long clock;
+        final long enqueuedAtNanos;
 
         Key(long clock) {
-            this.tries = 0;
-            this.clock = clock;
+            this(0, clock, System.nanoTime());
         }
 
-        private Key(long tries, long clock) {
+        private Key(long tries, long clock, long enqueuedAtNanos) {
             this.tries = tries;
             this.clock = clock;
+            this.enqueuedAtNanos = enqueuedAtNanos;
         }
 
         Key next() {
-            return new Key(tries + 1, clock);
+            return new Key(tries + 1, clock, enqueuedAtNanos);
         }
 
         @Override
@@ -52,17 +56,40 @@ class BoundedQueue {
 
     final TreeMap<Key, byte[]> items = new TreeMap<>();
 
-    long droppedItems;
-    long droppedBytes;
+    final Telemetry telemetry;
+    final LongSupplier nanos;
 
     Lock lock = new ReentrantLock();
     Condition notEmpty = lock.newCondition();
     Condition notFull = lock.newCondition();
 
     BoundedQueue(long maxBytes, long maxTries, WhenFull whenFull) {
+        this(maxBytes, maxTries, whenFull, null);
+    }
+
+    BoundedQueue(long maxBytes, long maxTries, WhenFull whenFull, Telemetry telemetry) {
+        this(maxBytes, maxTries, whenFull, telemetry, System::nanoTime);
+    }
+
+    BoundedQueue(
+            long maxBytes,
+            long maxTries,
+            WhenFull whenFull,
+            Telemetry telemetry,
+            LongSupplier nanos) {
         this.maxBytes = maxBytes;
         this.maxTries = maxTries;
         this.whenFull = whenFull;
+        this.telemetry = telemetry;
+        this.nanos = nanos;
+    }
+
+    long droppedPayloads;
+    long droppedBytes;
+
+    private void recordDrop(long bytes) {
+        droppedPayloads++;
+        droppedBytes += bytes;
     }
 
     void add(byte[] item) throws InterruptedException {
@@ -72,8 +99,7 @@ class BoundedQueue {
     void requeue(Map.Entry<Key, byte[]> item) throws InterruptedException {
         Key nextKey = item.getKey().next();
         if (nextKey.tries > maxTries) {
-            droppedItems++;
-            droppedBytes += item.getValue().length;
+            telemetry.onDrop(1, item.getValue().length);
             return;
         }
         put(nextKey, item.getValue(), WhenFull.DROP);
@@ -82,7 +108,7 @@ class BoundedQueue {
     // Must be called when lock is held.
     private Key newKey() {
         clock++;
-        return new Key(clock);
+        return new Key(0, clock, nanos.getAsLong());
     }
 
     private void put(Key key, byte[] item, WhenFull whenFull) throws InterruptedException {
@@ -96,7 +122,13 @@ class BoundedQueue {
             bytes += item.length;
             notEmpty.signal();
         } finally {
+            long droppedPayloads = this.droppedPayloads;
+            long droppedBytes = this.droppedBytes;
+            this.droppedPayloads = 0;
+            this.droppedBytes = 0;
             lock.unlock();
+            // Avoid potential lock ordering issues.
+            telemetry.onDrop(droppedPayloads, droppedBytes);
         }
     }
 
@@ -108,9 +140,8 @@ class BoundedQueue {
             switch (whenFull) {
                 case DROP:
                     Map.Entry<Key, byte[]> last = items.pollLastEntry();
-                    droppedItems++;
-                    droppedBytes += last.getValue().length;
                     bytes -= last.getValue().length;
+                    recordDrop(last.getValue().length);
                     break;
                 case BLOCK:
                     notFull.await();
@@ -129,6 +160,25 @@ class BoundedQueue {
             bytes -= item.getValue().length;
             notFull.signalAll();
             return item;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void snapshot(long now, Telemetry.Snapshot s) {
+        lock.lock();
+        try {
+            long oldestAge = 0L;
+            for (Key k : items.keySet()) {
+                long age = now - k.enqueuedAtNanos;
+                if (age > oldestAge) {
+                    oldestAge = age;
+                }
+            }
+            s.queuePayloads = items.size();
+            s.queueBytes = bytes;
+            s.queueMaxBytes = maxBytes;
+            s.oldestEnqueuedAgeNanos = oldestAge;
         } finally {
             lock.unlock();
         }

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
@@ -63,10 +63,6 @@ class BoundedQueue {
     Condition notEmpty = lock.newCondition();
     Condition notFull = lock.newCondition();
 
-    BoundedQueue(long maxBytes, long maxTries, WhenFull whenFull) {
-        this(maxBytes, maxTries, whenFull, null);
-    }
-
     BoundedQueue(long maxBytes, long maxTries, WhenFull whenFull, Telemetry telemetry) {
         this(maxBytes, maxTries, whenFull, telemetry, System::nanoTime);
     }

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -101,8 +101,8 @@ public class Forwarder extends Thread {
      *     ({@link WhenFull#BLOCK} mode only)
      */
     public void send(byte[] payload) throws InterruptedException {
-        telemetry.onEnqueue(payload.length);
         queue.add(payload);
+        telemetry.onEnqueue(payload.length);
     }
 
     void runOnce(Map.Entry<BoundedQueue.Key, byte[]> item) throws InterruptedException {

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -39,7 +39,7 @@ public class Forwarder extends Thread {
     String localData;
     String externalData;
 
-    int responseOk, responseBadRequest, responseOther;
+    final Telemetry telemetry;
 
     /**
      * Creates a new forwarder targeting the given URL.
@@ -60,13 +60,22 @@ public class Forwarder extends Thread {
             Duration connectTimeout,
             Duration requestTimeout) {
         this.url = url;
-        this.queue = new BoundedQueue(maxRequestsBytes, maxTries, whenFull);
+        this.telemetry = new Telemetry();
+        this.queue = new BoundedQueue(maxRequestsBytes, maxTries, whenFull, this.telemetry);
         this.requestTimeout = requestTimeout;
         this.client =
                 HttpClient.newBuilder()
                         .version(HttpClient.Version.HTTP_2)
                         .connectTimeout(connectTimeout)
                         .build();
+    }
+
+    /**
+     * Captures a snapshot of the forwarder's telemetry counters and queue state, clearing delta
+     * counters so subsequent snapshots report activity since this call.
+     */
+    public Telemetry.Snapshot snapshot() {
+        return telemetry.snapshot(queue);
     }
 
     /** Runs the forwarding loop, delivering queued payloads until the thread is interrupted. */
@@ -92,6 +101,7 @@ public class Forwarder extends Thread {
      *     ({@link WhenFull#BLOCK} mode only)
      */
     public void send(byte[] payload) throws InterruptedException {
+        telemetry.onEnqueue(payload.length);
         queue.add(payload);
     }
 
@@ -119,23 +129,24 @@ public class Forwarder extends Thread {
             logger.log(
                     Level.INFO, "response {0}: {1}", new Object[] {res.statusCode(), res.body()});
 
-            switch (res.statusCode()) {
+            int code = res.statusCode();
+            switch (code) {
                 case 400:
-                    responseBadRequest++;
+                    telemetry.onResponse(code, payload.length, false);
                     decreaseBackoff();
                     break;
                 case 200:
-                    responseOk++;
+                    telemetry.onResponse(code, payload.length, true);
                     decreaseBackoff();
                     break;
                 default:
-                    responseOther++;
+                    telemetry.onResponse(code, payload.length, false);
                     increaseBackoff();
                     queue.requeue(item);
             }
         } catch (IOException ex) {
             logger.log(Level.WARNING, "error sending request: {0}", ex.toString());
-            responseOther++;
+            telemetry.onTransportError(payload.length);
             increaseBackoff();
             queue.requeue(item);
         }

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -158,7 +158,8 @@ public class Forwarder extends Thread {
         }
     }
 
-    void handleTransportError(Map.Entry<BoundedQueue.Key, byte[]> item) throws InterruptedException {
+    void handleTransportError(Map.Entry<BoundedQueue.Key, byte[]> item)
+            throws InterruptedException {
         telemetry.onTransportError(item.getValue().length);
         increaseBackoff();
         queue.requeue(item);

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -122,21 +122,21 @@ public class Forwarder extends Thread {
             switch (res.statusCode()) {
                 case 400:
                     responseBadRequest++;
-                    onSuccess();
+                    decreaseBackoff();
                     break;
                 case 200:
                     responseOk++;
-                    onSuccess();
+                    decreaseBackoff();
                     break;
                 default:
                     responseOther++;
-                    onError();
+                    increaseBackoff();
                     queue.requeue(item);
             }
         } catch (IOException ex) {
             logger.log(Level.WARNING, "error sending request: {0}", ex.toString());
             responseOther++;
-            onError();
+            increaseBackoff();
             queue.requeue(item);
         }
 
@@ -145,11 +145,11 @@ public class Forwarder extends Thread {
 
     int delay;
 
-    void onSuccess() {
+    void decreaseBackoff() {
         delay >>= 4;
     }
 
-    void onError() {
+    void increaseBackoff() {
         if (delay < 64) delay <<= 1;
         if (delay == 0) delay = 1;
     }

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -129,29 +129,39 @@ public class Forwarder extends Thread {
             logger.log(
                     Level.INFO, "response {0}: {1}", new Object[] {res.statusCode(), res.body()});
 
-            int code = res.statusCode();
-            switch (code) {
-                case 400:
-                    telemetry.onResponse(code, payload.length, false);
-                    decreaseBackoff();
-                    break;
-                case 200:
-                    telemetry.onResponse(code, payload.length, true);
-                    decreaseBackoff();
-                    break;
-                default:
-                    telemetry.onResponse(code, payload.length, false);
-                    increaseBackoff();
-                    queue.requeue(item);
-            }
+            handleResponse(res.statusCode(), item);
         } catch (IOException ex) {
             logger.log(Level.WARNING, "error sending request: {0}", ex.toString());
-            telemetry.onTransportError(payload.length);
-            increaseBackoff();
-            queue.requeue(item);
+            handleTransportError(item);
         }
 
         backoff();
+    }
+
+    void handleResponse(int code, Map.Entry<BoundedQueue.Key, byte[]> item)
+            throws InterruptedException {
+        int len = item.getValue().length;
+        switch (code) {
+            case 400:
+                telemetry.onResponse(code, len, false);
+                telemetry.onDrop(1, len);
+                decreaseBackoff();
+                break;
+            case 200:
+                telemetry.onResponse(code, len, true);
+                decreaseBackoff();
+                break;
+            default:
+                telemetry.onResponse(code, len, false);
+                increaseBackoff();
+                queue.requeue(item);
+        }
+    }
+
+    void handleTransportError(Map.Entry<BoundedQueue.Key, byte[]> item) throws InterruptedException {
+        telemetry.onTransportError(item.getValue().length);
+        increaseBackoff();
+        queue.requeue(item);
     }
 
     int delay;

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/HttpCode.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/HttpCode.java
@@ -1,0 +1,47 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+/** Canonical telemetry labels for HTTP response codes. */
+final class HttpCode {
+
+    private static final String[] CATEGORIES = {"0xx", "1xx", "2xx", "3xx", "4xx", "5xx"};
+
+    private static final String[] NAMES = new String[506];
+
+    static {
+        for (int i = 0; i < NAMES.length; i++) {
+            NAMES[i] = CATEGORIES[i / 100];
+        }
+        NAMES[0] = "0";
+        NAMES[200] = "200";
+        NAMES[400] = "400";
+        NAMES[403] = "403";
+        NAMES[404] = "404";
+        NAMES[429] = "429";
+        NAMES[500] = "500";
+        NAMES[501] = "501";
+        NAMES[502] = "502";
+        NAMES[503] = "503";
+        NAMES[504] = "504";
+        NAMES[505] = "505";
+    }
+
+    private HttpCode() {}
+
+    static String name(int code) {
+        if (code >= 0 && code < NAMES.length) {
+            return NAMES[code];
+        }
+        int category = code / 100;
+        if (category >= 0 && category < CATEGORIES.length) {
+            return CATEGORIES[category];
+        }
+        return "xxx";
+    }
+}

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
@@ -1,0 +1,121 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+/** Thread-safe counter store for {@link Forwarder} telemetry. */
+public class Telemetry {
+
+    /** HTTP status code used to record transport-level (no-response) errors. */
+    public static final int TRANSPORT_ERROR_CODE = 0;
+
+    /** Point-in-time view of cumulative counters and queue state. */
+    public static final class Snapshot {
+        /**
+         * Wall-clock time (Unix epoch milliseconds) at the start of the interval covered by this
+         * snapshot — i.e., the moment of the previous snapshot, or telemetry construction if this
+         * is the first snapshot.
+         */
+        public long intervalStartMillis;
+
+        public long enqueuedPayloads;
+        public long deliveredPayloads;
+        public long enqueuedBytes;
+        public long deliveredBytes;
+        public long queuePayloads;
+        public long queueBytes;
+        public long queueMaxBytes;
+        public long droppedPayloads;
+        public long droppedBytes;
+
+        /** Nanos elapsed since the oldest queued item was enqueued; {@code 0} if queue is empty. */
+        public long oldestEnqueuedAgeNanos;
+
+        /** Nanos elapsed since the last successful submission; {@code 0} if none yet. */
+        public long lastSuccessAgeNanos;
+
+        /** Totals keyed by HTTP code. */
+        public Map<String, CodeCounters> byCode = new HashMap<>();
+
+        Snapshot(long intervalStartMillis) {
+            this.intervalStartMillis = intervalStartMillis;
+        }
+
+        /** Per-code totals within a snapshot's window. */
+        public static final class CodeCounters {
+            public long payloads;
+            public long bytes;
+        }
+    }
+
+    private final Clock clock;
+    private final LongSupplier nanos;
+
+    private Snapshot current;
+
+    private long lastSuccessNanos;
+    private boolean everDelivered;
+
+    public Telemetry() {
+        this(Clock.systemUTC(), System::nanoTime);
+    }
+
+    Telemetry(Clock clock, LongSupplier nanos) {
+        this.clock = clock;
+        this.nanos = nanos;
+        this.current = new Snapshot(clock.millis());
+    }
+
+    synchronized void onEnqueue(int len) {
+        current.enqueuedPayloads++;
+        current.enqueuedBytes += len;
+    }
+
+    synchronized void onResponse(int code, int len, boolean delivered) {
+        Snapshot.CodeCounters c =
+                current.byCode.computeIfAbsent(
+                        HttpCode.name(code), k -> new Snapshot.CodeCounters());
+        c.payloads++;
+        c.bytes += len;
+        if (delivered) {
+            current.deliveredPayloads++;
+            current.deliveredBytes += len;
+            lastSuccessNanos = nanos.getAsLong();
+            everDelivered = true;
+        }
+    }
+
+    synchronized void onTransportError(int len) {
+        onResponse(TRANSPORT_ERROR_CODE, len, false);
+    }
+
+    /** Records a dropped payload. */
+    synchronized void onDrop(long payloads, long bytes) {
+        current.droppedPayloads += payloads;
+        current.droppedBytes += bytes;
+    }
+
+    /**
+     * Captures a snapshot using the supplied queue stats, then swaps in a fresh accumulator so
+     * subsequent snapshots report deltas since this call.
+     */
+    public synchronized Snapshot snapshot(BoundedQueue q) {
+        long now = nanos.getAsLong();
+        Snapshot s = current;
+        current = new Snapshot(clock.millis());
+        s.lastSuccessAgeNanos = everDelivered ? now - lastSuccessNanos : 0L;
+        if (q != null) {
+            q.snapshot(now, s);
+        }
+        return s;
+    }
+}

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
@@ -28,7 +28,7 @@ public class BoundedQueueTest {
 
     @Test
     public void addThenNextReturnsItem() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP, new Telemetry());
         byte[] item = bytes(4);
         q.add(item);
         Map.Entry<BoundedQueue.Key, byte[]> entry = q.next();
@@ -38,7 +38,7 @@ public class BoundedQueueTest {
 
     @Test
     public void bytesDecrementedOnNext() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP, new Telemetry());
         q.add(bytes(3));
         q.add(bytes(3));
         q.add(bytes(3));
@@ -53,7 +53,7 @@ public class BoundedQueueTest {
 
     @Test
     public void newestItemDequeuesFirstWithinSameTries() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP, new Telemetry());
         byte[] a = {1};
         byte[] b = {2};
         byte[] c = {3};
@@ -70,15 +70,17 @@ public class BoundedQueueTest {
 
     @Test
     public void dropWhenFullDropsOldestItem() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP);
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP, t);
         byte[] a = bytes(5); // added first → smallest clock → last in TreeMap
         byte[] b = bytes(4);
         q.add(a); // queue: a(clock=MIN+1)
         q.add(b); // queue full: a, b
         byte[] c = bytes(3);
         q.add(c); // a (oldest, last entry) evicted
-        assertEquals(1, q.droppedItems);
-        assertEquals(5, q.droppedBytes);
+        Telemetry.Snapshot s = t.snapshot(q);
+        assertEquals(1, s.droppedPayloads);
+        assertEquals(5, s.droppedBytes);
         // Remaining: c (newest, clock=MIN+3) then b (clock=MIN+2)
         assertSame(c, q.next().getValue());
         assertSame(b, q.next().getValue());
@@ -86,17 +88,19 @@ public class BoundedQueueTest {
 
     @Test
     public void dropCountersAccumulate() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP);
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP, t);
         q.add(bytes(5)); // fills queue (X)
         q.add(bytes(5)); // X dropped (Y in)
         q.add(bytes(5)); // Y dropped (Z in)
-        assertEquals(2, q.droppedItems);
-        assertEquals(10, q.droppedBytes);
+        Telemetry.Snapshot s = t.snapshot(q);
+        assertEquals(2, s.droppedPayloads);
+        assertEquals(10, s.droppedBytes);
     }
 
     @Test(timeout = 3000)
     public void dropDoesNotBlock() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP, new Telemetry());
         q.add(bytes(5)); // fill
         q.add(bytes(5)); // should return immediately via DROP
     }
@@ -105,7 +109,8 @@ public class BoundedQueueTest {
 
     @Test(timeout = 5000)
     public void blockUnblocksWhenSpaceFreed() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.BLOCK);
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.BLOCK, t);
         q.add(bytes(5)); // queue full
 
         Thread producer =
@@ -129,40 +134,49 @@ public class BoundedQueueTest {
         producer.join(2000);
         assertFalse(producer.isAlive());
         assertEquals(5, q.bytes);
-        assertEquals(0, q.droppedItems);
+        assertEquals(0, t.snapshot(q).droppedPayloads);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void addThrowsForOversizedItem() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(4, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(4, 1, WhenFull.DROP, new Telemetry());
         q.add(bytes(5));
     }
 
     @Test
     public void requeueIncrementsTriesPreservesClock() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP, new Telemetry());
         q.add(bytes(4));
         Map.Entry<BoundedQueue.Key, byte[]> entry = q.next();
         assertEquals(0, entry.getKey().tries);
         long originalClock = entry.getKey().clock;
+        long originalEnqueued = entry.getKey().enqueuedAtNanos;
 
         q.requeue(entry);
         Map.Entry<BoundedQueue.Key, byte[]> requeued = q.next();
         assertEquals(1, requeued.getKey().tries);
         assertEquals(originalClock, requeued.getKey().clock);
-        assertEquals(0, q.droppedItems);
+        assertEquals(originalEnqueued, requeued.getKey().enqueuedAtNanos);
     }
 
     @Test
     public void requeuedItemDequeuesAfterFreshItems() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP);
+        MockNanos nanos = new MockNanos(0);
+        BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP, new Telemetry(), nanos);
         byte[] a = {10};
         byte[] b = {20};
-        q.add(a);
+        q.add(a); // A.enqueuedAtNanos = 0
         Map.Entry<BoundedQueue.Key, byte[]> entryA = q.next();
         q.requeue(entryA); // A now has tries=1
 
+        nanos.advanceMillis(5);
         q.add(b); // B has tries=0 → higher priority
+
+        // Snapshot sees A as the oldest even though B was added later.
+        Telemetry.Snapshot s = new Telemetry.Snapshot(0L);
+        q.snapshot(nanos.getAsLong(), s);
+        assertEquals(2, s.queuePayloads);
+        assertEquals(5_000_000L, s.oldestEnqueuedAgeNanos);
 
         assertSame(b, q.next().getValue()); // B first (fewer tries)
         assertSame(a, q.next().getValue()); // A second
@@ -170,19 +184,21 @@ public class BoundedQueueTest {
 
     @Test
     public void requeueAtMaxTriesIsAccepted() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP);
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP, t);
         q.add(bytes(3));
         Map.Entry<BoundedQueue.Key, byte[]> e = q.next();
         q.requeue(e); // tries → 1
         e = q.next();
         q.requeue(e); // tries → 2 == maxTries, should be accepted
-        assertEquals(0, q.droppedItems);
+        assertEquals(0, t.snapshot(q).droppedPayloads);
         assertFalse(q.items.isEmpty());
     }
 
     @Test
     public void requeuePastMaxTriesDropsItem() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP);
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP, t);
         byte[] item = bytes(7);
         q.add(item);
         Map.Entry<BoundedQueue.Key, byte[]> e = q.next();
@@ -191,15 +207,44 @@ public class BoundedQueueTest {
         q.requeue(e); // tries → 2 == maxTries, accepted
         e = q.next();
         q.requeue(e); // tries → 3 > maxTries, dropped
-        assertEquals(1, q.droppedItems);
-        assertEquals(7, q.droppedBytes);
+        Telemetry.Snapshot s = t.snapshot(q);
+        assertEquals(1, s.droppedPayloads);
+        assertEquals(7, s.droppedBytes);
         assertEquals(0, q.bytes);
         assertTrue(q.items.isEmpty());
     }
 
+    // --- snapshot ---
+
+    @Test
+    public void snapshotEmptyQueue() {
+        BoundedQueue q = new BoundedQueue(20, 1, WhenFull.DROP, new Telemetry());
+        Telemetry.Snapshot s = new Telemetry.Snapshot(0L);
+        q.snapshot(System.nanoTime(), s);
+        assertEquals(0, s.queuePayloads);
+        assertEquals(0, s.queueBytes);
+        assertEquals(20, s.queueMaxBytes);
+        assertEquals(0L, s.oldestEnqueuedAgeNanos);
+    }
+
+    @Test
+    public void snapshotReports() throws InterruptedException {
+        BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP, new Telemetry());
+        q.add(bytes(3));
+        q.add(bytes(5));
+
+        Telemetry.Snapshot s = new Telemetry.Snapshot(0L);
+        q.snapshot(System.nanoTime(), s);
+        assertEquals(2, s.queuePayloads);
+        assertEquals(8, s.queueBytes);
+        assertEquals(30, s.queueMaxBytes);
+        // The oldest item was enqueued before the snapshot, so age must be positive.
+        assertTrue(s.oldestEnqueuedAgeNanos > 0);
+    }
+
     @Test(timeout = 5000)
     public void nextBlocksUntilItemAdded() throws InterruptedException {
-        BoundedQueue q = new BoundedQueue(100, 1, WhenFull.DROP);
+        BoundedQueue q = new BoundedQueue(100, 1, WhenFull.DROP, new Telemetry());
         byte[] item = bytes(3);
         Map.Entry<BoundedQueue.Key, byte[]>[] result = new Map.Entry[1];
 

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -8,6 +8,7 @@
 package com.datadoghq.dogstatsd.http.forwarder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import java.net.URI;
@@ -48,7 +49,7 @@ public class ForwarderTest {
 
     /** A 400 response means the payload won't be retried, so it counts as a drop. */
     @Test
-    public void fourHundredCountsAsDrop() throws Exception {
+    public void handle400() throws Exception {
         Forwarder f = newForwarder(100, WhenFull.DROP);
         f.send(new byte[7]);
         Map.Entry<BoundedQueue.Key, byte[]> item = f.queue.next();
@@ -59,5 +60,58 @@ public class ForwarderTest {
         assertEquals(1, s.droppedPayloads);
         assertEquals(7, s.droppedBytes);
         assertEquals(0, s.deliveredPayloads);
+    }
+
+    @Test
+    public void handle200() throws Exception {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.send(new byte[7]);
+        Map.Entry<BoundedQueue.Key, byte[]> item = f.queue.next();
+        f.handleResponse(200, item);
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(1, s.deliveredPayloads);
+        assertEquals(7, s.deliveredBytes);
+        assertEquals(0, s.droppedPayloads);
+        assertEquals(0, s.queuePayloads);
+        Telemetry.Snapshot.CodeCounters cc = s.byCode.get("200");
+        assertNotNull(cc);
+        assertEquals(1, cc.payloads);
+        assertEquals(7, cc.bytes);
+    }
+
+    /** Transport errors put the item back on the queue (within {@code maxTries}) for a retry. */
+    @Test
+    public void handleError() throws Exception {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.send(new byte[7]);
+        Map.Entry<BoundedQueue.Key, byte[]> item = f.queue.next();
+        f.handleTransportError(item);
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(0, s.deliveredPayloads);
+        assertEquals(0, s.droppedPayloads);
+        assertEquals(1, s.queuePayloads);
+        assertEquals(7, s.queueBytes);
+        Telemetry.Snapshot.CodeCounters cc = s.byCode.get("0");
+        assertNotNull(cc);
+        assertEquals(1, cc.payloads);
+        assertEquals(7, cc.bytes);
+    }
+
+    /** Unrecognized response codes are recorded and the item is requeued for retry. */
+    @Test
+    public void handle500() throws Exception {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.send(new byte[7]);
+        Map.Entry<BoundedQueue.Key, byte[]> item = f.queue.next();
+        f.handleResponse(500, item);
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(0, s.deliveredPayloads);
+        assertEquals(0, s.droppedPayloads);
+        assertEquals(1, s.queuePayloads);
+        assertEquals(7, s.queueBytes);
+        Telemetry.Snapshot.CodeCounters cc = s.byCode.get("500");
+        assertNotNull(cc);
+        assertEquals(1, cc.payloads);
+        assertEquals(7, cc.bytes);
     }
 }

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.Test;
 
 public class ForwarderTest {
@@ -43,5 +44,20 @@ public class ForwarderTest {
         Telemetry.Snapshot s = f.snapshot();
         assertEquals(0, s.enqueuedPayloads);
         assertEquals(0, s.enqueuedBytes);
+    }
+
+    /** A 400 response means the payload won't be retried, so it counts as a drop. */
+    @Test
+    public void fourHundredCountsAsDrop() throws Exception {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.send(new byte[7]);
+        Map.Entry<BoundedQueue.Key, byte[]> item = f.queue.next();
+        f.handleResponse(400, item);
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(1, s.enqueuedPayloads);
+        assertEquals(7, s.enqueuedBytes);
+        assertEquals(1, s.droppedPayloads);
+        assertEquals(7, s.droppedBytes);
+        assertEquals(0, s.deliveredPayloads);
     }
 }

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -1,0 +1,47 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.net.URI;
+import java.time.Duration;
+import org.junit.Test;
+
+public class ForwarderTest {
+
+    private static Forwarder newForwarder(long maxBytes, WhenFull whenFull) {
+        return new Forwarder(
+                URI.create("http://localhost:0/"),
+                maxBytes,
+                1,
+                whenFull,
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void sendCountsEnqueue() throws InterruptedException {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.send(new byte[7]);
+        f.send(new byte[3]);
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(2, s.enqueuedPayloads);
+        assertEquals(10, s.enqueuedBytes);
+    }
+
+    @Test
+    public void oversizedSendDoesNotCount() {
+        Forwarder f = newForwarder(10, WhenFull.DROP);
+        assertThrows(IllegalArgumentException.class, () -> f.send(new byte[11]));
+        Telemetry.Snapshot s = f.snapshot();
+        assertEquals(0, s.enqueuedPayloads);
+        assertEquals(0, s.enqueuedBytes);
+    }
+}

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/MockClock.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/MockClock.java
@@ -1,0 +1,40 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/** Manually-advanced wall clock for deterministic interval-start tests. */
+final class MockClock extends Clock {
+    private Instant instant;
+
+    MockClock(Instant initial) {
+        this.instant = initial;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return ZoneId.of("UTC");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant instant() {
+        return instant;
+    }
+
+    void advanceMillis(long millis) {
+        instant = instant.plusMillis(millis);
+    }
+}

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/MockNanos.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/MockNanos.java
@@ -1,0 +1,28 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import java.util.function.LongSupplier;
+
+/** Manually-advanced nanoTime source for deterministic age tests. */
+final class MockNanos implements LongSupplier {
+    private long nanos;
+
+    MockNanos(long initial) {
+        this.nanos = initial;
+    }
+
+    void advanceMillis(long millis) {
+        nanos += millis * 1_000_000L;
+    }
+
+    @Override
+    public long getAsLong() {
+        return nanos;
+    }
+}

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/TelemetryTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/TelemetryTest.java
@@ -1,0 +1,171 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Clock;
+import java.time.Instant;
+import org.junit.Test;
+
+public class TelemetryTest {
+
+    private static void assertCounters(
+            long expectedPayloads, long expectedBytes, Telemetry.Snapshot.CodeCounters c) {
+        assertNotNull(c);
+        assertEquals(expectedPayloads, c.payloads);
+        assertEquals(expectedBytes, c.bytes);
+    }
+
+    @Test
+    public void freshState() {
+        Telemetry t = new Telemetry();
+        Telemetry.Snapshot s = t.snapshot(null);
+        assertEquals(0, s.enqueuedBytes);
+        assertEquals(0, s.deliveredBytes);
+        assertEquals(0, s.enqueuedPayloads);
+        assertEquals(0, s.deliveredPayloads);
+        assertEquals(0L, s.lastSuccessAgeNanos);
+        assertEquals(0L, s.oldestEnqueuedAgeNanos);
+        assertTrue(s.byCode.isEmpty());
+    }
+
+    @Test
+    public void enqueue() {
+        Telemetry t = new Telemetry();
+        t.onEnqueue(10);
+        t.onEnqueue(25);
+        t.onEnqueue(5);
+        Telemetry.Snapshot s = t.snapshot(null);
+        assertEquals(3, s.enqueuedPayloads);
+        assertEquals(40, s.enqueuedBytes);
+        assertEquals(0, s.deliveredBytes);
+        assertEquals(0, s.deliveredPayloads);
+    }
+
+    /** byCode tracks every response; only {@code delivered=true} feeds the delivered totals. */
+    @Test
+    public void responses() {
+        Telemetry t = new Telemetry();
+        t.onResponse(200, 17, true);
+        t.onResponse(200, 23, true);
+        t.onResponse(400, 13, false);
+        t.onTransportError(99);
+        t.onTransportError(101);
+        Telemetry.Snapshot s = t.snapshot(null);
+
+        // Only delivered (200) responses count toward delivered totals.
+        assertEquals(2, s.deliveredPayloads);
+        assertEquals(40, s.deliveredBytes);
+
+        // Each code has its own byCode entry; repeated calls accumulate. Transport errors are
+        // bucketed under "0".
+        assertCounters(2, 40, s.byCode.get("200"));
+        assertCounters(1, 13, s.byCode.get("400"));
+        assertCounters(2, 200, s.byCode.get("0"));
+
+        // Codes that never saw a response don't appear.
+        assertNull(s.byCode.get("404"));
+    }
+
+    @Test
+    public void queueState() throws InterruptedException {
+        Telemetry t = new Telemetry();
+        BoundedQueue q = new BoundedQueue(100, 1, WhenFull.DROP, t);
+        q.add(new byte[5]);
+        q.add(new byte[7]);
+        Telemetry.Snapshot s = t.snapshot(q);
+        assertEquals(2, s.queuePayloads);
+        assertEquals(12, s.queueBytes);
+        assertEquals(100, s.queueMaxBytes);
+        assertTrue(s.oldestEnqueuedAgeNanos >= 0);
+    }
+
+    /** Each snapshot captures and clears the counters so subsequent snapshots are deltas. */
+    @Test
+    public void deltaSemantics() {
+        Telemetry t = new Telemetry();
+        t.onEnqueue(10);
+        t.onResponse(200, 5, true);
+        t.onResponse(503, 7, false);
+        t.onDrop(1, 10);
+        t.onDrop(1, 25);
+        Telemetry.Snapshot s1 = t.snapshot(null);
+        assertEquals(1, s1.enqueuedPayloads);
+        assertEquals(10, s1.enqueuedBytes);
+        assertEquals(1, s1.deliveredPayloads);
+        assertEquals(5, s1.deliveredBytes);
+        assertEquals(2, s1.droppedPayloads);
+        assertEquals(35, s1.droppedBytes);
+        assertCounters(1, 5, s1.byCode.get("200"));
+        assertCounters(1, 7, s1.byCode.get("503"));
+
+        // No activity since s1 — every counter resets to zero and byCode is empty.
+        Telemetry.Snapshot s2 = t.snapshot(null);
+        assertEquals(0, s2.enqueuedPayloads);
+        assertEquals(0, s2.enqueuedBytes);
+        assertEquals(0, s2.deliveredPayloads);
+        assertEquals(0, s2.deliveredBytes);
+        assertEquals(0, s2.droppedPayloads);
+        assertEquals(0, s2.droppedBytes);
+        assertTrue(s2.byCode.isEmpty());
+
+        // Only the new activity shows up in s3.
+        t.onResponse(200, 11, true);
+        Telemetry.Snapshot s3 = t.snapshot(null);
+        assertEquals(1, s3.deliveredPayloads);
+        assertEquals(11, s3.deliveredBytes);
+        assertCounters(1, 11, s3.byCode.get("200"));
+        assertNull(s3.byCode.get("503"));
+    }
+
+    /** intervalStartMillis is the wall-clock time of the previous snapshot (or construction). */
+    @Test
+    public void intervalStart() {
+        MockClock clock = new MockClock(Instant.parse("2026-01-01T00:00:00Z"));
+        Telemetry t = new Telemetry(clock, System::nanoTime);
+        long constructionMillis = clock.millis();
+
+        clock.advanceMillis(10);
+        Telemetry.Snapshot s1 = t.snapshot(null);
+        // First snapshot's interval starts at construction time.
+        assertEquals(constructionMillis, s1.intervalStartMillis);
+
+        clock.advanceMillis(5);
+        Telemetry.Snapshot s2 = t.snapshot(null);
+        // Second snapshot's interval starts at the moment of the first snapshot.
+        assertEquals(constructionMillis + 10, s2.intervalStartMillis);
+    }
+
+    /**
+     * lastSuccessAgeNanos = (snapshot time) − (most recent delivery); grows until next delivery.
+     */
+    @Test
+    public void lastSuccessAge() {
+        MockNanos nanos = new MockNanos(0);
+        Telemetry t = new Telemetry(Clock.systemUTC(), nanos);
+
+        // First success at t=0.
+        t.onResponse(200, 1, true);
+
+        // Window 1: age = time since the success.
+        nanos.advanceMillis(7);
+        assertEquals(7_000_000L, t.snapshot(null).lastSuccessAgeNanos);
+
+        // Window 2 with no new delivery: age keeps growing.
+        nanos.advanceMillis(3);
+        assertEquals(10_000_000L, t.snapshot(null).lastSuccessAgeNanos);
+
+        // A new delivery resets the reference point; age is 0 if snapshotted at the same nano.
+        t.onResponse(200, 1, true);
+        assertEquals(0L, t.snapshot(null).lastSuccessAgeNanos);
+    }
+}


### PR DESCRIPTION
Keep track of number of enqueued, delivered and dropped payloads, as well as http responses and queue state.

There is no code to actually send the telemetry yet, this will be added in a subsequent PR.