### PR TITLE
AGTMETRICS-489 Refactor forwarder to handle multiple URLs

### DIFF
--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
@@ -50,7 +50,7 @@ class BoundedQueue {
     final long maxTries;
     final WhenFull whenFull;
 
-    final TreeMap<Key, byte[]> items = new TreeMap<>();
+    final TreeMap<Key, Payload> items = new TreeMap<>();
 
     long droppedItems;
     long droppedBytes;
@@ -65,15 +65,15 @@ class BoundedQueue {
         this.whenFull = whenFull;
     }
 
-    void add(byte[] item) throws InterruptedException {
+    void add(Payload item) throws InterruptedException {
         put(null, item, whenFull);
     }
 
-    void requeue(Map.Entry<Key, byte[]> item) throws InterruptedException {
+    void requeue(Map.Entry<Key, Payload> item) throws InterruptedException {
         Key nextKey = item.getKey().next();
         if (nextKey.tries > maxTries) {
             droppedItems++;
-            droppedBytes += item.getValue().length;
+            droppedBytes += item.getValue().bytes.length;
             return;
         }
         put(nextKey, item.getValue(), WhenFull.DROP);
@@ -85,15 +85,15 @@ class BoundedQueue {
         return new Key(clock);
     }
 
-    private void put(Key key, byte[] item, WhenFull whenFull) throws InterruptedException {
+    private void put(Key key, Payload item, WhenFull whenFull) throws InterruptedException {
         lock.lock();
         try {
             if (key == null) {
                 key = newKey();
             }
-            ensureSpace(item.length, whenFull);
+            ensureSpace(item.bytes.length, whenFull);
             items.put(key, item);
-            bytes += item.length;
+            bytes += item.bytes.length;
             notEmpty.signal();
         } finally {
             lock.unlock();
@@ -107,10 +107,10 @@ class BoundedQueue {
         while (bytes + length > maxBytes) {
             switch (whenFull) {
                 case DROP:
-                    Map.Entry<Key, byte[]> last = items.pollLastEntry();
+                    Map.Entry<Key, Payload> last = items.pollLastEntry();
                     droppedItems++;
-                    droppedBytes += last.getValue().length;
-                    bytes -= last.getValue().length;
+                    droppedBytes += last.getValue().bytes.length;
+                    bytes -= last.getValue().bytes.length;
                     break;
                 case BLOCK:
                     notFull.await();
@@ -119,14 +119,14 @@ class BoundedQueue {
         }
     }
 
-    Map.Entry<Key, byte[]> next() throws InterruptedException {
+    Map.Entry<Key, Payload> next() throws InterruptedException {
         lock.lock();
         try {
             while (items.size() == 0) {
                 notEmpty.await();
             }
-            Map.Entry<Key, byte[]> item = items.pollFirstEntry();
-            bytes -= item.getValue().length;
+            Map.Entry<Key, Payload> item = items.pollFirstEntry();
+            bytes -= item.getValue().bytes.length;
             notFull.signalAll();
             return item;
         } finally {

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -24,14 +24,13 @@ import java.util.logging.Logger;
 /**
  * An HTTP forwarder that delivers DogStatsD HTTP payloads to a remote endpoint.
  *
- * <p>Payloads are enqueued via {@link #send(byte[])} and delivered asynchronously by a background
- * thread. Failed requests are retried with exponential back-off up to {@code maxTries} attempts
- * before being discarded.
+ * <p>Payloads are enqueued via {@link #send(URI, byte[])} and delivered asynchronously by a
+ * background thread. Failed requests are retried with exponential back-off up to {@code maxTries}
+ * attempts before being discarded.
  */
 public class Forwarder extends Thread {
     static final Logger logger = Logger.getLogger(Forwarder.class.getName());
     final BoundedQueue queue;
-    final URI url;
     final HttpClient client;
     final Duration requestTimeout;
     final Random rng = new Random();
@@ -42,9 +41,8 @@ public class Forwarder extends Thread {
     int responseOk, responseBadRequest, responseOther;
 
     /**
-     * Creates a new forwarder targeting the given URL.
+     * Creates a new forwarder.
      *
-     * @param url the remote HTTP endpoint to POST payloads to
      * @param maxRequestsBytes maximum total size of buffered payloads, in bytes
      * @param maxTries maximum number of delivery attempts per payload
      * @param whenFull action to take when the queue is at capacity
@@ -53,13 +51,11 @@ public class Forwarder extends Thread {
      *     {@code null} disables the request timeout
      */
     public Forwarder(
-            URI url,
             long maxRequestsBytes,
             long maxTries,
             WhenFull whenFull,
             Duration connectTimeout,
             Duration requestTimeout) {
-        this.url = url;
         this.queue = new BoundedQueue(maxRequestsBytes, maxTries, whenFull);
         this.requestTimeout = requestTimeout;
         this.client =
@@ -82,25 +78,29 @@ public class Forwarder extends Thread {
     }
 
     /**
-     * Enqueues a payload for delivery to the remote endpoint.
+     * Enqueues a payload for delivery to the given endpoint.
      *
      * <p>If the queue is full, behaviour is determined by the {@link WhenFull} policy supplied at
      * construction time.
      *
+     * @param url the remote HTTP endpoint to POST the payload to
      * @param payload the raw bytes to deliver
      * @throws InterruptedException if the calling thread is interrupted while waiting for space
      *     ({@link WhenFull#BLOCK} mode only)
      */
-    public void send(byte[] payload) throws InterruptedException {
-        queue.add(payload);
+    public void send(URI url, byte[] payload) throws InterruptedException {
+        queue.add(new Payload(url, payload));
     }
 
-    void runOnce(Map.Entry<BoundedQueue.Key, byte[]> item) throws InterruptedException {
-        byte[] payload = item.getValue();
-        logger.log(Level.INFO, "sending {0} bytes", payload.length);
+    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item) throws InterruptedException {
+        Payload payload = item.getValue();
+        logger.log(
+                Level.INFO,
+                "sending {0} bytes to {1}",
+                new Object[] {payload.bytes.length, payload.url});
 
         HttpRequest.Builder builder =
-                HttpRequest.newBuilder(url).POST(BodyPublishers.ofByteArray(payload));
+                HttpRequest.newBuilder(payload.url).POST(BodyPublishers.ofByteArray(payload.bytes));
         if (requestTimeout != null) {
             builder.timeout(requestTimeout);
         }

--- a/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Payload.java
+++ b/dogstatsd-http-forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Payload.java
@@ -1,0 +1,20 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+package com.datadoghq.dogstatsd.http.forwarder;
+
+import java.net.URI;
+
+class Payload {
+    final URI url;
+    final byte[] bytes;
+
+    Payload(URI url, byte[] bytes) {
+        this.url = url;
+        this.bytes = bytes;
+    }
+}

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
@@ -9,11 +9,14 @@ package com.datadoghq.dogstatsd.http.forwarder;
 
 import static org.junit.Assert.*;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
 import org.junit.Test;
 
 public class BoundedQueueTest {
+    private static final URI URL = URI.create("http://example.invalid/");
+
     private static byte[] bytes(int n) {
         return bytes(n, (byte) 0);
     }
@@ -24,14 +27,22 @@ public class BoundedQueueTest {
         return b;
     }
 
+    private static Payload payload(int n) {
+        return new Payload(URL, bytes(n));
+    }
+
+    private static Payload payload(byte[] b) {
+        return new Payload(URL, b);
+    }
+
     // --- Round-trip / bytes tracking ---
 
     @Test
     public void addThenNextReturnsItem() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP);
-        byte[] item = bytes(4);
+        Payload item = payload(4);
         q.add(item);
-        Map.Entry<BoundedQueue.Key, byte[]> entry = q.next();
+        Map.Entry<BoundedQueue.Key, Payload> entry = q.next();
         assertSame(item, entry.getValue());
         assertEquals(0, q.bytes);
     }
@@ -39,9 +50,9 @@ public class BoundedQueueTest {
     @Test
     public void bytesDecrementedOnNext() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP);
-        q.add(bytes(3));
-        q.add(bytes(3));
-        q.add(bytes(3));
+        q.add(payload(3));
+        q.add(payload(3));
+        q.add(payload(3));
         assertEquals(9, q.bytes);
         q.next();
         assertEquals(6, q.bytes);
@@ -54,9 +65,9 @@ public class BoundedQueueTest {
     @Test
     public void newestItemDequeuesFirstWithinSameTries() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(30, 1, WhenFull.DROP);
-        byte[] a = {1};
-        byte[] b = {2};
-        byte[] c = {3};
+        Payload a = payload(new byte[] {1});
+        Payload b = payload(new byte[] {2});
+        Payload c = payload(new byte[] {3});
         q.add(a);
         q.add(b);
         q.add(c);
@@ -71,11 +82,11 @@ public class BoundedQueueTest {
     @Test
     public void dropWhenFullDropsOldestItem() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP);
-        byte[] a = bytes(5); // added first → smallest clock → last in TreeMap
-        byte[] b = bytes(4);
+        Payload a = payload(5); // added first → smallest clock → last in TreeMap
+        Payload b = payload(4);
         q.add(a); // queue: a(clock=MIN+1)
         q.add(b); // queue full: a, b
-        byte[] c = bytes(3);
+        Payload c = payload(3);
         q.add(c); // a (oldest, last entry) evicted
         assertEquals(1, q.droppedItems);
         assertEquals(5, q.droppedBytes);
@@ -87,9 +98,9 @@ public class BoundedQueueTest {
     @Test
     public void dropCountersAccumulate() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP);
-        q.add(bytes(5)); // fills queue (X)
-        q.add(bytes(5)); // X dropped (Y in)
-        q.add(bytes(5)); // Y dropped (Z in)
+        q.add(payload(5)); // fills queue (X)
+        q.add(payload(5)); // X dropped (Y in)
+        q.add(payload(5)); // Y dropped (Z in)
         assertEquals(2, q.droppedItems);
         assertEquals(10, q.droppedBytes);
     }
@@ -97,8 +108,8 @@ public class BoundedQueueTest {
     @Test(timeout = 3000)
     public void dropDoesNotBlock() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(5, 1, WhenFull.DROP);
-        q.add(bytes(5)); // fill
-        q.add(bytes(5)); // should return immediately via DROP
+        q.add(payload(5)); // fill
+        q.add(payload(5)); // should return immediately via DROP
     }
 
     // --- WhenFull.BLOCK ---
@@ -106,13 +117,13 @@ public class BoundedQueueTest {
     @Test(timeout = 5000)
     public void blockUnblocksWhenSpaceFreed() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(5, 1, WhenFull.BLOCK);
-        q.add(bytes(5)); // queue full
+        q.add(payload(5)); // queue full
 
         Thread producer =
                 new Thread(
                         () -> {
                             try {
-                                q.add(bytes(5));
+                                q.add(payload(5));
                             } catch (InterruptedException e) {
                                 return;
                             }
@@ -135,19 +146,19 @@ public class BoundedQueueTest {
     @Test(expected = IllegalArgumentException.class)
     public void addThrowsForOversizedItem() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(4, 1, WhenFull.DROP);
-        q.add(bytes(5));
+        q.add(payload(5));
     }
 
     @Test
     public void requeueIncrementsTriesPreservesClock() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP);
-        q.add(bytes(4));
-        Map.Entry<BoundedQueue.Key, byte[]> entry = q.next();
+        q.add(payload(4));
+        Map.Entry<BoundedQueue.Key, Payload> entry = q.next();
         assertEquals(0, entry.getKey().tries);
         long originalClock = entry.getKey().clock;
 
         q.requeue(entry);
-        Map.Entry<BoundedQueue.Key, byte[]> requeued = q.next();
+        Map.Entry<BoundedQueue.Key, Payload> requeued = q.next();
         assertEquals(1, requeued.getKey().tries);
         assertEquals(originalClock, requeued.getKey().clock);
         assertEquals(0, q.droppedItems);
@@ -156,10 +167,10 @@ public class BoundedQueueTest {
     @Test
     public void requeuedItemDequeuesAfterFreshItems() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(20, 3, WhenFull.DROP);
-        byte[] a = {10};
-        byte[] b = {20};
+        Payload a = payload(new byte[] {10});
+        Payload b = payload(new byte[] {20});
         q.add(a);
-        Map.Entry<BoundedQueue.Key, byte[]> entryA = q.next();
+        Map.Entry<BoundedQueue.Key, Payload> entryA = q.next();
         q.requeue(entryA); // A now has tries=1
 
         q.add(b); // B has tries=0 → higher priority
@@ -171,8 +182,8 @@ public class BoundedQueueTest {
     @Test
     public void requeueAtMaxTriesIsAccepted() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP);
-        q.add(bytes(3));
-        Map.Entry<BoundedQueue.Key, byte[]> e = q.next();
+        q.add(payload(3));
+        Map.Entry<BoundedQueue.Key, Payload> e = q.next();
         q.requeue(e); // tries → 1
         e = q.next();
         q.requeue(e); // tries → 2 == maxTries, should be accepted
@@ -183,9 +194,8 @@ public class BoundedQueueTest {
     @Test
     public void requeuePastMaxTriesDropsItem() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(20, 2, WhenFull.DROP);
-        byte[] item = bytes(7);
-        q.add(item);
-        Map.Entry<BoundedQueue.Key, byte[]> e = q.next();
+        q.add(payload(7));
+        Map.Entry<BoundedQueue.Key, Payload> e = q.next();
         q.requeue(e); // tries → 1
         e = q.next();
         q.requeue(e); // tries → 2 == maxTries, accepted
@@ -200,8 +210,8 @@ public class BoundedQueueTest {
     @Test(timeout = 5000)
     public void nextBlocksUntilItemAdded() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(100, 1, WhenFull.DROP);
-        byte[] item = bytes(3);
-        Map.Entry<BoundedQueue.Key, byte[]>[] result = new Map.Entry[1];
+        Payload item = payload(3);
+        Map.Entry<BoundedQueue.Key, Payload>[] result = new Map.Entry[1];
 
         Thread consumer =
                 new Thread(

--- a/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http-forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -20,12 +20,7 @@ public class ForwarderTest {
     private static final URI URL = URI.create("http://localhost:0/");
 
     private static Forwarder newForwarder(long maxBytes, WhenFull whenFull) {
-        return new Forwarder(
-                maxBytes,
-                1,
-                whenFull,
-                Duration.ofSeconds(1),
-                Duration.ofSeconds(1));
+        return new Forwarder(maxBytes, 1, whenFull, Duration.ofSeconds(1), Duration.ofSeconds(1));
     }
 
     @Test


### PR DESCRIPTION
Forwarder still logically represents a single destination, urls are expected to point to the same agent, differing only in the path for different payload types.