### PR TITLE
Allow forwarder to be stopped cleanly

### DIFF
--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
@@ -62,6 +62,7 @@ class BoundedQueue {
     Lock lock = new ReentrantLock();
     Condition notEmpty = lock.newCondition();
     Condition notFull = lock.newCondition();
+    boolean closed;
 
     BoundedQueue(long maxBytes, long maxTries, WhenFull whenFull, Telemetry telemetry) {
         this(maxBytes, maxTries, whenFull, telemetry, System::nanoTime);
@@ -111,6 +112,11 @@ class BoundedQueue {
         lock.lock();
         try {
             if (key == null) {
+                // Queue is closed for new items, but retries are allowed to enter.
+                if (closed) {
+                    throw new IllegalStateException("closed");
+                }
+
                 key = newKey();
             }
             ensureSpace(item.bytes.length, whenFull);
@@ -141,6 +147,9 @@ class BoundedQueue {
                     break;
                 case BLOCK:
                     notFull.await();
+                    if (closed) {
+                        throw new IllegalStateException("closed");
+                    }
                     break;
             }
         }
@@ -150,12 +159,26 @@ class BoundedQueue {
         lock.lock();
         try {
             while (items.size() == 0) {
+                if (closed) {
+                    return null;
+                }
                 notEmpty.await();
             }
             Map.Entry<Key, Payload> item = items.pollFirstEntry();
             bytes -= item.getValue().bytes.length;
             notFull.signalAll();
             return item;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void close() {
+        lock.lock();
+        try {
+            closed = true;
+            notEmpty.signalAll();
+            notFull.signalAll();
         } finally {
             lock.unlock();
         }

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueue.java
@@ -158,7 +158,7 @@ class BoundedQueue {
     Map.Entry<Key, Payload> next() throws InterruptedException {
         lock.lock();
         try {
-            while (items.size() == 0) {
+            while (empty()) {
                 if (closed) {
                     return null;
                 }
@@ -201,5 +201,9 @@ class BoundedQueue {
         } finally {
             lock.unlock();
         }
+    }
+
+    boolean empty() {
+        return items.size() == 0;
     }
 }

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -246,7 +246,8 @@ public class Forwarder extends Thread {
      * timeout} elapses, whichever comes first. If the timeout elapses first the forwarding thread
      * is interrupted, abandoning any unsent payloads.
      *
-     * @param timeout maximum time to wait for the backlog to drain. {@code null} means wait forever.
+     * @param timeout maximum time to wait for the backlog to drain. {@code null} means wait
+     *     forever.
      * @return {@code true} if the queue drained cleanly with no unsent payloads remaining; {@code
      *     false} if the timeout elapsed with data still queued
      * @throws InterruptedException if the calling thread is interrupted while waiting

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -246,14 +246,21 @@ public class Forwarder extends Thread {
      * timeout} elapses, whichever comes first. If the timeout elapses first the forwarding thread
      * is interrupted, abandoning any unsent payloads.
      *
-     * @param timeout maximum time to wait for the backlog to drain
+     * @param timeout maximum time to wait for the backlog to drain. {@code null} means wait forever.
      * @return {@code true} if the queue drained cleanly with no unsent payloads remaining; {@code
      *     false} if the timeout elapsed with data still queued
      * @throws InterruptedException if the calling thread is interrupted while waiting
      */
     public boolean close(Duration timeout) throws InterruptedException {
         queue.close();
-        join(timeout.toMillis());
+        if (timeout == null) {
+            join(0);
+        } else {
+            long timeoutMs = timeout.toMillis();
+            if (timeoutMs > 0) {
+                join(timeoutMs);
+            }
+        }
         if (isAlive()) {
             interrupt();
             join();

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -264,8 +264,7 @@ public class Forwarder extends Thread {
         if (isAlive()) {
             interrupt();
             join();
-            return false;
         }
-        return true;
+        return queue.empty();
     }
 }

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -79,9 +79,13 @@ public class Forwarder extends Thread {
     /** Runs the forwarding loop, delivering queued payloads until the thread is interrupted. */
     @Override
     public void run() {
-        while (true) {
+        while (!interrupted()) {
             try {
-                runOnce(queue.next());
+                Map.Entry<BoundedQueue.Key, Payload> item = queue.next();
+                if (item == null) {
+                    return;
+                }
+                runOnce(item);
             } catch (InterruptedException e) {
                 return;
             } catch (Exception t) {
@@ -100,6 +104,7 @@ public class Forwarder extends Thread {
      * @param payload the raw bytes to deliver
      * @throws InterruptedException if the calling thread is interrupted while waiting for space
      *     ({@link WhenFull#BLOCK} mode only)
+     * @throws IllegalStateException if the forwarder has been closed via {@link #close(Duration)}
      */
     public void send(URI url, byte[] payload) throws InterruptedException {
         Objects.requireNonNull(url, "url");
@@ -139,6 +144,10 @@ public class Forwarder extends Thread {
         } catch (IOException ex) {
             logger.log(Level.WARNING, "error sending request: {0}", ex.toString());
             handleTransportError(item);
+        } catch (InterruptedException ex) {
+            // Wouldn't be retried, but will show up as a leftover in a telemetry snapshot.
+            queue.requeue(item);
+            throw ex;
         }
 
         backoff();
@@ -228,5 +237,28 @@ public class Forwarder extends Thread {
         if (!validHeaderValue.matcher(value).matches()) {
             throw new IllegalArgumentException("invalid character");
         }
+    }
+
+    /**
+     * Closes the forwarder: stops accepting new payloads and drains the remaining backlog.
+     *
+     * <p>Already-queued payloads keep being delivered until either the queue drains or {@code
+     * timeout} elapses, whichever comes first. If the timeout elapses first the forwarding thread
+     * is interrupted, abandoning any unsent payloads.
+     *
+     * @param timeout maximum time to wait for the backlog to drain
+     * @return {@code true} if the queue drained cleanly with no unsent payloads remaining; {@code
+     *     false} if the timeout elapsed with data still queued
+     * @throws InterruptedException if the calling thread is interrupted while waiting
+     */
+    public boolean close(Duration timeout) throws InterruptedException {
+        queue.close();
+        join(timeout.toMillis());
+        if (isAlive()) {
+            interrupt();
+            join();
+            return false;
+        }
+        return true;
     }
 }

--- a/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
+++ b/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/BoundedQueueTest.java
@@ -148,6 +148,49 @@ public class BoundedQueueTest {
         assertEquals(0, t.snapshot(q).droppedPayloads);
     }
 
+    @Test(timeout = 5000)
+    public void closeUnblocksProducerWithException() throws InterruptedException {
+        BoundedQueue q = new BoundedQueue(5, 1, WhenFull.BLOCK, new Telemetry());
+        q.add(payload(5)); // queue full
+
+        Throwable[] thrown = new Throwable[1];
+        Thread producer =
+                new Thread(
+                        () -> {
+                            try {
+                                q.add(payload(5));
+                            } catch (Throwable t) {
+                                thrown[0] = t;
+                            }
+                        });
+        producer.start();
+
+        // Give the producer time to reach await().
+        while (!(producer.getState() == Thread.State.WAITING
+                || producer.getState() == Thread.State.TIMED_WAITING)) {
+            Thread.sleep(50);
+        }
+
+        q.close();
+        producer.join(2000);
+        assertFalse(producer.isAlive());
+        assertTrue(thrown[0] instanceof IllegalStateException);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void addAfterCloseThrows() throws InterruptedException {
+        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP, new Telemetry());
+        q.close();
+        q.add(payload(3));
+    }
+
+    @Test
+    public void nextReturnsNullWhenClosedAndEmpty() throws InterruptedException {
+        BoundedQueue q = new BoundedQueue(10, 1, WhenFull.DROP, new Telemetry());
+        q.close();
+        assertNull(q.next());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void addThrowsForOversizedItem() throws InterruptedException {
         BoundedQueue q = new BoundedQueue(4, 1, WhenFull.DROP, new Telemetry());

--- a/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -158,10 +158,14 @@ public class ForwarderTest {
         Forwarder f =
                 new Forwarder(100, 1, WhenFull.DROP, Duration.ofSeconds(1), Duration.ofSeconds(1)) {
                     @Override
-                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item)
-                            throws InterruptedException {
-                        entered.countDown();
-                        Thread.sleep(Long.MAX_VALUE);
+                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item) throws InterruptedException {
+                        try {
+                            entered.countDown();
+                            Thread.sleep(Long.MAX_VALUE);
+                        } catch (InterruptedException ex) {
+                            queue.requeue(item);
+                            throw ex;
+                        }
                     }
                 };
         f.send(URL, new byte[3]);

--- a/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -158,7 +158,8 @@ public class ForwarderTest {
         Forwarder f =
                 new Forwarder(100, 1, WhenFull.DROP, Duration.ofSeconds(1), Duration.ofSeconds(1)) {
                     @Override
-                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item) throws InterruptedException {
+                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item)
+                            throws InterruptedException {
                         try {
                             entered.countDown();
                             Thread.sleep(Long.MAX_VALUE);

--- a/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
+++ b/dogstatsd-http/forwarder/src/test/java/com/datadoghq/dogstatsd/http/forwarder/ForwarderTest.java
@@ -8,12 +8,16 @@
 package com.datadoghq.dogstatsd.http.forwarder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 public class ForwarderTest {
@@ -108,5 +112,62 @@ public class ForwarderTest {
         assertNotNull(cc);
         assertEquals(1, cc.payloads);
         assertEquals(7, cc.bytes);
+    }
+
+    /** With an empty queue, close() unblocks the loop's next() and drains cleanly. */
+    @Test(timeout = 5000)
+    public void closeDrainsEmptyQueueReturnsTrue() throws InterruptedException {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        f.start();
+        assertTrue(f.close(Duration.ofSeconds(5)));
+        assertFalse(f.isAlive());
+    }
+
+    /** Payloads queued before close() are all delivered before the thread exits. */
+    @Test(timeout = 5000)
+    public void closeDrainsPendingItemsReturnsTrue() throws InterruptedException {
+        AtomicInteger processed = new AtomicInteger();
+        Forwarder f =
+                new Forwarder(100, 1, WhenFull.DROP, Duration.ofSeconds(1), Duration.ofSeconds(1)) {
+                    @Override
+                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item) {
+                        processed.incrementAndGet();
+                    }
+                };
+        f.send(URL, new byte[3]);
+        f.send(URL, new byte[3]);
+        f.send(URL, new byte[3]);
+        f.start();
+        assertTrue(f.close(Duration.ofSeconds(5)));
+        assertFalse(f.isAlive());
+        assertEquals(3, processed.get());
+    }
+
+    /** After close(), send() propagates the closed-queue IllegalStateException. */
+    @Test
+    public void sendAfterCloseThrows() throws InterruptedException {
+        Forwarder f = newForwarder(100, WhenFull.DROP);
+        assertTrue(f.close(Duration.ofSeconds(1)));
+        assertThrows(IllegalStateException.class, () -> f.send(URL, new byte[3]));
+    }
+
+    /** If the backlog can't drain in time, close() interrupts the thread and returns false. */
+    @Test(timeout = 5000)
+    public void closeTimesOutReturnsFalse() throws InterruptedException {
+        CountDownLatch entered = new CountDownLatch(1);
+        Forwarder f =
+                new Forwarder(100, 1, WhenFull.DROP, Duration.ofSeconds(1), Duration.ofSeconds(1)) {
+                    @Override
+                    void runOnce(Map.Entry<BoundedQueue.Key, Payload> item)
+                            throws InterruptedException {
+                        entered.countDown();
+                        Thread.sleep(Long.MAX_VALUE);
+                    }
+                };
+        f.send(URL, new byte[3]);
+        f.start();
+        entered.await();
+        assertFalse(f.close(Duration.ofMillis(200)));
+        assertFalse(f.isAlive());
     }
 }


### PR DESCRIPTION
Add a blocking stop method that takes a timeout and tries to send any pending payloads before returning.