### PR TITLE
Improve javadoc

### DIFF
--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
@@ -59,6 +59,12 @@ public class Sketch {
 
     /** Receives (key, count) pairs from {@link #bins(BinConsumer)}. */
     public interface BinConsumer {
+        /**
+         * Process one sketch bin.
+         *
+         * @param key a value that specifies the range of observations counted in this bin.
+         * @param count number of observations in the bin.
+         */
         void consumeBin(short key, long count);
     }
 
@@ -69,7 +75,11 @@ public class Sketch {
         return size;
     }
 
-    /** Feeds each populated bin to {@code consumer} in order. */
+    /**
+     * Feeds each populated bin to {@code consumer} in order.
+     *
+     * @param consumer A consumer to feed sketch bins to.
+     */
     public void bins(BinConsumer consumer) {
         int idx = head;
         for (int i = 0; i < size; i++) {

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
@@ -13,8 +13,7 @@ import java.util.Arrays;
  * Reusable DDSketch builder. Consumes a batch of observations and populates sum, min, max, count
  * and distribution bins accordingly.
  *
- * <p>This implementation maintains at most 4096 bins with 64-bit counters. The number of bins is a
- * hard limit and is enforced by the intake.
+ * <p>This implementation maintains at most 4096 bins with 64-bit counters.
  *
  * <p>Prioritizes accuracy of higher key bins (higher percentiles) over lower ones when the number
  * of bins exceeds the limit.

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
@@ -13,11 +13,11 @@ import java.util.Arrays;
  * Reusable DDSketch builder. Consumes a batch of observations and populates sum, min, max, count
  * and distribution bins accordingly.
  *
- * <p>This implementation maintains at most 4096 bins with 64-bit counters. Number of bins is a hard
- * limit and is enforced by the intake.
+ * <p>This implementation maintains at most 4096 bins with 64-bit counters. The number of bins is a
+ * hard limit and is enforced by the intake.
  *
- * <p>Prioritizes accuracy of higher key bins (higher percentiles) over lower ones when number of
- * bins exceeds the limit.
+ * <p>Prioritizes accuracy of higher key bins (higher percentiles) over lower ones when the number
+ * of bins exceeds the limit.
  */
 public class Sketch {
     static final double gamma = 130.0 / 128;
@@ -78,7 +78,7 @@ public class Sketch {
     /**
      * Feeds each populated bin to {@code consumer} in order.
      *
-     * @param consumer A consumer to feed sketch bins to.
+     * @param consumer a consumer to feed sketch bins to.
      */
     public void bins(BinConsumer consumer) {
         int idx = head;
@@ -124,7 +124,7 @@ public class Sketch {
     /**
      * Builds the sketch from the given values.
      *
-     * @param observations the observations to include in the sketch
+     * @param observations the observations to include in the sketch.
      * @param sampleRate the sampling rate used to collect {@code observations}, in {@code (0, 1]}.
      *     Each observation is weighted by {@code 1 / sampleRate} when accumulating counts and sums.
      *     Rates below ~1.08e-19 saturate the per-observation weight; bin counts and the total
@@ -146,7 +146,7 @@ public class Sketch {
     /**
      * Builds the sketch from the given values.
      *
-     * @param observations the observations to include in the sketch
+     * @param observations the observations to include in the sketch.
      * @param sampleRate the sampling rate used to collect {@code observations}, in {@code (0, 1]}.
      *     Each observation is weighted by {@code 1 / sampleRate} when accumulating counts and sums.
      *     Rates below ~1.08e-19 saturate the per-observation weight; bin counts and the total

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/Sketch.java
@@ -129,6 +129,8 @@ public class Sketch {
      *     Each observation is weighted by {@code 1 / sampleRate} when accumulating counts and sums.
      *     Rates below ~1.08e-19 saturate the per-observation weight; bin counts and the total
      *     {@code count} field saturate at {@link Long#MAX_VALUE} on overflow.
+     * @throws IllegalArgumentException if {@code sampleRate} is {@code NaN}, not positive, or
+     *     greater than 1.
      */
     public void build(long[] observations, double sampleRate) {
         validateSampleRate(sampleRate);
@@ -151,6 +153,8 @@ public class Sketch {
      *     Each observation is weighted by {@code 1 / sampleRate} when accumulating counts and sums.
      *     Rates below ~1.08e-19 saturate the per-observation weight; bin counts and the total
      *     {@code count} field saturate at {@link Long#MAX_VALUE} on overflow.
+     * @throws IllegalArgumentException if {@code sampleRate} is {@code NaN}, not positive, or
+     *     greater than 1.
      */
     public void build(double[] observations, double sampleRate) {
         validateSampleRate(sampleRate);

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
@@ -35,6 +35,7 @@ public class DirectHttpClient {
      *
      * @param forwarder the forwarder used to send payloads, required.
      * @return a new builder.
+     * @throws NullPointerException if {@code forwarder} is null.
      */
     public static Builder builder(final Forwarder forwarder) {
         return new Builder(forwarder);
@@ -126,6 +127,7 @@ public class DirectHttpClient {
      * @param value the gauge value.
      * @param ts the timestamp of the point in seconds since Unix epoch.
      * @param tags the tags to attach to the point.
+     * @throws BufferOverflowException if the encoded metric exceeds the maximum payload size.
      */
     public void gauge(String name, double value, long ts, List<String> tags) {
         seriesBuilder
@@ -146,6 +148,7 @@ public class DirectHttpClient {
      * @param value the count accumulated over the interval starting at {@code ts}.
      * @param ts the timestamp of the point in seconds since Unix epoch.
      * @param tags the tags to attach to the point.
+     * @throws BufferOverflowException if the encoded metric exceeds the maximum payload size.
      */
     public void count(String name, double value, long ts, List<String> tags) {
         seriesBuilder
@@ -164,6 +167,9 @@ public class DirectHttpClient {
      * @param sampleRate the sampling rate used to collect {@code values}, in {@code (0, 1]}.
      * @param ts the timestamp of the point in seconds since Unix epoch.
      * @param tags the tags to attach to the point.
+     * @throws IllegalArgumentException if {@code sampleRate} is {@code NaN}, not positive, or
+     *     greater than 1.
+     * @throws BufferOverflowException if the encoded metric exceeds the maximum payload size.
      */
     public void distribution(
             String name, double[] values, double sampleRate, long ts, List<String> tags) {
@@ -175,7 +181,11 @@ public class DirectHttpClient {
         return prefix.isEmpty() ? name : prefix + name;
     }
 
-    /** Completes any in-progress payloads and submits them to the forwarder. */
+    /**
+     * Completes any in-progress payloads and submits them to the forwarder.
+     *
+     * @throws BufferOverflowException if an encoded metric exceeds the maximum payload size.
+     */
     public void flush() {
         seriesBuilder.close();
         sketchesBuilder.close();

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
@@ -11,6 +11,7 @@ import com.datadoghq.dogstatsd.Sketch;
 import com.datadoghq.dogstatsd.http.serializer.PayloadBuilder;
 import com.datadoghq.dogstatsd.http.serializer.PayloadConsumer;
 import java.net.URI;
+import java.nio.BufferOverflowException;
 import java.util.List;
 import java.util.Objects;
 

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/DirectHttpClient.java
@@ -139,7 +139,8 @@ public class DirectHttpClient {
     /**
      * Records a count point.
      *
-     * <p>For compatibility with aggregated dogstatsd counts, assumes aggregation interval of 10s.
+     * <p>For compatibility with aggregated dogstatsd counts, assumes an aggregation interval of
+     * 10s.
      *
      * @param name the metric name, to which the client prefix is prepended.
      * @param value the count accumulated over the interval starting at {@code ts}.

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
@@ -31,6 +31,12 @@ public class ForwarderContext {
         return new Builder();
     }
 
+    /**
+     * Returns the base URI that per-payload URIs are resolved against. Always ends with {@code /}
+     * so that it acts as a prefix for {@link URI#resolve}.
+     *
+     * @return the base URI, never null.
+     */
     public URI baseUri() {
         return baseUri;
     }
@@ -112,7 +118,7 @@ public class ForwarderContext {
          * Sets the base URI the series and sketches endpoints are resolved against. Defaults to the
          * value of the {@code DD_DOGSTATSD_HTTP_URL} environment variable.
          *
-         * @param val the base URI, or null to use the default.
+         * @param uri the base URI, or null to use the default.
          * @return this builder.
          */
         public Builder baseUri(final String uri) {
@@ -120,6 +126,12 @@ public class ForwarderContext {
             return this;
         }
 
+        /**
+         * Use the supplied map instead of OS environment variables.
+         *
+         * @param val the environment map.
+         * @return this builder.
+         */
         public Builder environment(final Map<String, String> val) {
             env = new EnvMap(val);
             return this;
@@ -134,7 +146,6 @@ public class ForwarderContext {
          * Builds the context, running detection for any value not set explicitly.
          *
          * @return a new context.
-         * @throws URISyntaxException if baseUri value is not a valid URI.
          */
         public ForwarderContext build() {
             String local = localData;

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
@@ -61,9 +61,9 @@ public class ForwarderContext {
     }
 
     /**
-     * Returns new instance with default settings.
+     * Returns a new instance with default settings.
      *
-     * @return new default instance.
+     * @return a new default instance.
      */
     public static ForwarderContext defaults() {
         return builder().build();

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/ForwarderContext.java
@@ -64,6 +64,8 @@ public class ForwarderContext {
      * Returns a new instance with default settings.
      *
      * @return a new default instance.
+     * @throws IllegalStateException if {@code DD_DOGSTATSD_HTTP_URL} is not defined.
+     * @throws IllegalArgumentException if the base URI is malformed.
      */
     public static ForwarderContext defaults() {
         return builder().build();
@@ -146,6 +148,9 @@ public class ForwarderContext {
          * Builds the context, running detection for any value not set explicitly.
          *
          * @return a new context.
+         * @throws IllegalStateException if no base URI was set with {@link #baseUri} and {@code
+         *     DD_DOGSTATSD_HTTP_URL} is not defined.
+         * @throws IllegalArgumentException if the base URI is malformed.
          */
         public ForwarderContext build() {
             String local = localData;

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/Buffer.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/Buffer.java
@@ -41,7 +41,7 @@ abstract class Buffer {
         size = 0;
     }
 
-    /** Return true if buf is null or empty */
+    /** Return true if buf is null or empty. */
     static boolean isEmpty(Buffer buf) {
         return buf == null || buf.size == 0;
     }

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/Metric.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/Metric.java
@@ -42,6 +42,7 @@ abstract class Metric<T extends Metric<T>> {
      * @param resources List of even length, containing zero or more (type, name) pairs, or null for
      *     no resources.
      * @return This.
+     * @throws IllegalArgumentException if {@code resources} has an odd number of elements.
      */
     public T setResources(List<String> resources) {
         if (resources != null && resources.size() % 2 != 0) {
@@ -100,7 +101,13 @@ abstract class Metric<T extends Metric<T>> {
         pb.encodeOrigin(origin);
     }
 
-    /** Finish this timeseries and add it to the payload. */
+    /**
+     * Finish this timeseries and add it to the payload.
+     *
+     * @throws java.nio.BufferOverflowException if the encoded metric exceeds the maximum payload
+     *     size. The in-progress metric is discarded, so no {@link PayloadBuilder#resetMetric()} is
+     *     needed before encoding further metrics.
+     */
     public void close() {
         pb.endMetric();
     }

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilder.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilder.java
@@ -135,7 +135,7 @@ public class PayloadBuilder {
     Metric<?> metricInProgress;
 
     /**
-     * Create new PayloadBuilder.
+     * Create a new PayloadBuilder.
      *
      * @param consumer Is given payloads one by one as they are finished.
      */
@@ -145,12 +145,12 @@ public class PayloadBuilder {
     }
 
     /**
-     * Begin encoding new count metric.
+     * Begin encoding a new count metric.
      *
      * <p>Only one metric can be encoded at a time.
      *
      * @param name Name of the metric.
-     * @return Builder instance.
+     * @return New builder instance.
      */
     public ScalarMetric count(String name) {
         ScalarMetric m = new ScalarMetric(this, 1, name);
@@ -159,7 +159,7 @@ public class PayloadBuilder {
     }
 
     /**
-     * Begin encoding new rate metric.
+     * Begin encoding a new rate metric.
      *
      * <p>Only one metric can be encoded at a time.
      *
@@ -173,7 +173,7 @@ public class PayloadBuilder {
     }
 
     /**
-     * Begin encoding new gauge metric.
+     * Begin encoding a new gauge metric.
      *
      * <p>Only one metric can be encoded at a time.
      *
@@ -187,7 +187,7 @@ public class PayloadBuilder {
     }
 
     /**
-     * Begin encoding new sketch metric.
+     * Begin encoding a new sketch metric.
      *
      * <p>Only one metric can be encoded at a time.
      *

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilder.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadBuilder.java
@@ -151,6 +151,7 @@ public class PayloadBuilder {
      *
      * @param name Name of the metric.
      * @return New builder instance.
+     * @throws BufferOverflowException if finishing the previous metric overflows the payload.
      */
     public ScalarMetric count(String name) {
         ScalarMetric m = new ScalarMetric(this, 1, name);
@@ -165,6 +166,7 @@ public class PayloadBuilder {
      *
      * @param name Name of the metric.
      * @return New builder instance.
+     * @throws BufferOverflowException if finishing the previous metric overflows the payload.
      */
     public ScalarMetric rate(String name) {
         ScalarMetric m = new ScalarMetric(this, 2, name);
@@ -179,6 +181,7 @@ public class PayloadBuilder {
      *
      * @param name Name of the metric.
      * @return New builder instance.
+     * @throws BufferOverflowException if finishing the previous metric overflows the payload.
      */
     public ScalarMetric gauge(String name) {
         ScalarMetric m = new ScalarMetric(this, 3, name);
@@ -193,6 +196,7 @@ public class PayloadBuilder {
      *
      * @param name Name of the metric.
      * @return New builder instance.
+     * @throws BufferOverflowException if finishing the previous metric overflows the payload.
      */
     public SketchMetric sketch(String name) {
         SketchMetric m = new SketchMetric(this, 4, name);
@@ -305,7 +309,11 @@ public class PayloadBuilder {
         timestampsDelta.clear();
     }
 
-    /** Finish any pending data. */
+    /**
+     * Finish any pending data.
+     *
+     * @throws BufferOverflowException if finishing the in-progress metric overflows the payload.
+     */
     public void close() {
         endMetric();
         flushPayload();

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadConsumer.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/PayloadConsumer.java
@@ -10,7 +10,7 @@ package com.datadoghq.dogstatsd.http.serializer;
 /** Consumes payloads from the PayloadBuilder. */
 public interface PayloadConsumer {
     /**
-     * Called when payload builder finishes another payload.
+     * Called when the payload builder finishes another payload.
      *
      * @param payload Completed payload.
      */

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/ScalarMetric.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/ScalarMetric.java
@@ -19,7 +19,7 @@ public class ScalarMetric extends Metric<ScalarMetric> {
     }
 
     /**
-     * Add new data point to the timeseries.
+     * Add a new data point to the timeseries.
      *
      * @param timestamp Timestamp of the point in seconds since Unix epoch.
      * @param value Metric value at timestamp.

--- a/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/SketchMetric.java
+++ b/dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/serializer/SketchMetric.java
@@ -53,6 +53,9 @@ public class SketchMetric extends Metric<SketchMetric> {
      * @param timestamp Timestamp of the point in seconds since Unix epoch.
      * @param sketch Sketch supplying the summary statistics and bin distribution.
      * @return This.
+     * @throws BufferOverflowException if the sketch's bin data alone would exceed the maximum
+     *     payload size. The metric is no longer valid; call {@link PayloadBuilder#resetMetric()}
+     *     before encoding any further metrics.
      */
     public SketchMetric addPoint(long timestamp, Sketch sketch) {
         // Skip doing the work if just the bin data would exceed payload size limit.

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -112,6 +112,9 @@ public class Forwarder extends Thread {
      * @throws InterruptedException if the calling thread is interrupted while waiting for space
      *     ({@link WhenFull#BLOCK} mode only).
      * @throws IllegalStateException if the forwarder has been closed via {@link #close(Duration)}.
+     * @throws IllegalArgumentException if {@code payload} is larger than the queue's {@link
+     *     Builder#maxRequestsBytes} limit, in which case it can never be delivered.
+     * @throws NullPointerException if {@code url} or {@code payload} is null.
      */
     public void send(URI url, byte[] payload) throws InterruptedException {
         Objects.requireNonNull(url, "url");
@@ -256,6 +259,7 @@ public class Forwarder extends Thread {
          *
          * @param val the maximum number of buffered bytes; must be positive.
          * @return this builder.
+         * @throws IllegalArgumentException if {@code val} is not positive.
          */
         public Builder maxRequestsBytes(final long val) {
             if (val <= 0) {
@@ -270,6 +274,7 @@ public class Forwarder extends Thread {
          *
          * @param val the maximum number of attempts; must be at least 1.
          * @return this builder.
+         * @throws IllegalArgumentException if {@code val} is less than 1.
          */
         public Builder maxTries(final long val) {
             if (val < 1) {
@@ -284,6 +289,7 @@ public class Forwarder extends Thread {
          *
          * @param val the action to take.
          * @return this builder.
+         * @throws NullPointerException if {@code val} is null.
          */
         public Builder whenFull(final WhenFull val) {
             whenFull = Objects.requireNonNull(val, "whenFull");
@@ -295,6 +301,8 @@ public class Forwarder extends Thread {
          *
          * @param val the connect timeout; must be positive.
          * @return this builder.
+         * @throws NullPointerException if {@code val} is null.
+         * @throws IllegalArgumentException if {@code val} is not positive.
          */
         public Builder connectTimeout(final Duration val) {
             Objects.requireNonNull(val, "connectTimeout");
@@ -312,6 +320,7 @@ public class Forwarder extends Thread {
          * @param val the request timeout, or {@code null} to disable it; must be positive when
          *     non-null.
          * @return this builder.
+         * @throws IllegalArgumentException if {@code val} is non-null and not positive.
          */
         public Builder requestTimeout(final Duration val) {
             if (val != null && (val.isNegative() || val.isZero())) {
@@ -328,6 +337,9 @@ public class Forwarder extends Thread {
          *
          * @param context the context to take the values from.
          * @return this builder.
+         * @throws NullPointerException if {@code context} is null.
+         * @throws IllegalArgumentException if the context's local or external data contains
+         *     characters that are not valid in an HTTP header value.
          */
         public Builder context(final ForwarderContext context) {
             contextSet = true;
@@ -343,6 +355,8 @@ public class Forwarder extends Thread {
          * started yet.
          *
          * @return a new forwarder.
+         * @throws IllegalStateException if no context was set with {@link #context} and the default
+         *     one cannot be built because {@code DD_DOGSTATSD_HTTP_URL} is not defined.
          */
         public Forwarder build() {
             if (!contextSet) {

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -76,6 +76,8 @@ public class Forwarder extends Thread {
     /**
      * Captures a snapshot of the forwarder's telemetry counters and queue state, clearing delta
      * counters so subsequent snapshots report activity since this call.
+     *
+     * @return a telemetry snapshot.
      */
     public Telemetry.Snapshot snapshot() {
         return telemetry.snapshot(queue);

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Forwarder.java
@@ -104,14 +104,14 @@ public class Forwarder extends Thread {
     /**
      * Enqueues a payload for delivery to the given endpoint.
      *
-     * <p>If the queue is full, behaviour is determined by the {@link WhenFull} policy set with
+     * <p>If the queue is full, behavior is determined by the {@link WhenFull} policy set with
      * {@link Builder#whenFull}.
      *
-     * @param url the remote HTTP endpoint to POST the payload to
-     * @param payload the raw bytes to deliver
+     * @param url the remote HTTP endpoint to POST the payload to.
+     * @param payload the raw bytes to deliver.
      * @throws InterruptedException if the calling thread is interrupted while waiting for space
-     *     ({@link WhenFull#BLOCK} mode only)
-     * @throws IllegalStateException if the forwarder has been closed via {@link #close(Duration)}
+     *     ({@link WhenFull#BLOCK} mode only).
+     * @throws IllegalStateException if the forwarder has been closed via {@link #close(Duration)}.
      */
     public void send(URI url, byte[] payload) throws InterruptedException {
         Objects.requireNonNull(url, "url");
@@ -215,8 +215,8 @@ public class Forwarder extends Thread {
      * @param timeout maximum time to wait for the backlog to drain. {@code null} means wait
      *     forever.
      * @return {@code true} if the queue drained cleanly with no unsent payloads remaining; {@code
-     *     false} if the timeout elapsed with data still queued
-     * @throws InterruptedException if the calling thread is interrupted while waiting
+     *     false} if the timeout elapsed with data still queued.
+     * @throws InterruptedException if the calling thread is interrupted while waiting.
      */
     public boolean close(Duration timeout) throws InterruptedException {
         queue.close();

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
@@ -54,7 +54,9 @@ public class Telemetry {
         /** Total size in bytes of payloads dropped in this interval. */
         public long droppedBytes;
 
-        /** Nanos elapsed since the oldest queued item was enqueued; {@code 0} if queue is empty. */
+        /**
+         * Nanos elapsed since the oldest queued item was enqueued; {@code 0} if the queue is empty.
+         */
         public long oldestEnqueuedAgeNanos;
 
         /** Nanos elapsed since the last successful submission; {@code 0} if none yet. */
@@ -63,7 +65,7 @@ public class Telemetry {
         /** Totals keyed by HTTP code. */
         public Map<String, CodeCounters> byCode = new HashMap<>();
 
-        /** Default metric name prefix used when none is supplied to {@link Snapshot#encode}. */
+        /** Default metric name prefix used when none is supplied to {@link Snapshot#encodeTo}. */
         static final String DEFAULT_PREFIX = "datadog.dogstatsd_http.client";
 
         Snapshot(long intervalStartMillis) {

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
@@ -128,7 +128,7 @@ public class Telemetry {
     private long lastSuccessNanos;
     private boolean everDelivered;
 
-    public Telemetry() {
+    Telemetry() {
         this(Clock.systemUTC(), System::nanoTime);
     }
 
@@ -167,11 +167,7 @@ public class Telemetry {
         current.droppedBytes += bytes;
     }
 
-    /**
-     * Captures a snapshot using the supplied queue stats, then swaps in a fresh accumulator so
-     * subsequent snapshots report deltas since this call.
-     */
-    public synchronized Snapshot snapshot(BoundedQueue q) {
+    synchronized Snapshot snapshot(BoundedQueue q) {
         long now = nanos.getAsLong();
         Snapshot s = current;
         current = new Snapshot(clock.millis());

--- a/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
+++ b/dogstatsd-http/forwarder/src/main/java/com/datadoghq/dogstatsd/http/forwarder/Telemetry.java
@@ -18,7 +18,7 @@ public class Telemetry {
     /** HTTP status code used to record transport-level (no-response) errors. */
     public static final int TRANSPORT_ERROR_CODE = 0;
 
-    /** Point-in-time view of cumulative counters and queue state. */
+    /** Queue state at snapshot time, plus counters for the interval leading up to it. */
     public static final class Snapshot {
         /**
          * Wall-clock time (Unix epoch milliseconds) at the start of the interval covered by this
@@ -27,14 +27,31 @@ public class Telemetry {
          */
         public long intervalStartMillis;
 
+        /** Number of payloads added to the queue in this interval. */
         public long enqueuedPayloads;
+
+        /** Number of payloads successfully delivered in this interval. */
         public long deliveredPayloads;
+
+        /** Total size in bytes of payloads added to the queue in this interval. */
         public long enqueuedBytes;
+
+        /** Total size in bytes of payloads successfully delivered in this interval. */
         public long deliveredBytes;
+
+        /** Number of payloads currently in the queue. */
         public long queuePayloads;
+
+        /** Total size in bytes of payloads currently in the queue. */
         public long queueBytes;
+
+        /** Maximum number of bytes the queue is allowed to store. */
         public long queueMaxBytes;
+
+        /** Number of payloads dropped in this interval. */
         public long droppedPayloads;
+
+        /** Total size in bytes of payloads dropped in this interval. */
         public long droppedBytes;
 
         /** Nanos elapsed since the oldest queued item was enqueued; {@code 0} if queue is empty. */
@@ -115,7 +132,10 @@ public class Telemetry {
 
         /** Per-code totals within a snapshot's window. */
         public static final class CodeCounters {
+            /** Number of payloads. */
             public long payloads;
+
+            /** Total size in bytes of payloads. */
             public long bytes;
         }
     }


### PR DESCRIPTION
Add missing docs, correct warnings from the javadoc tool, add missing `@throws` for unchecked exceptions, and grammar and spelling fixes.