### PR TITLE
Add java module system declarations

### DIFF
--- a/dogstatsd-http/core/pom.xml
+++ b/dogstatsd-http/core/pom.xml
@@ -39,6 +39,20 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <!-- Provide stable JPMS name to the artifact.
+                             Causes `mvn test` to fail on with a module error, use `mvn package` instead. -->
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.datadoghq.dogstatsd.http</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/dogstatsd-http/forwarder/src/main/java/module-info.java
+++ b/dogstatsd-http/forwarder/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+/* Unless explicitly stated otherwise all files in this repository are
+ * licensed under the Apache 2.0 License.
+ *
+ * This product includes software developed at Datadog
+ *  (https://www.datadoghq.com/) Copyright 2026 Datadog, Inc.
+ */
+
+/** HTTP forwarder for DogStatsD metrics. */
+module com.datadoghq.dogstatsd.http.forwarder {
+    requires transitive com.datadoghq.dogstatsd.http;
+    requires java.net.http;
+    requires java.logging;
+
+    exports com.datadoghq.dogstatsd.http.forwarder;
+}


### PR DESCRIPTION
Core is in Java 7, so it can only have automatic module name, set via jar manifest.

Forwarder gets a real declaration, which declares a transitive dependency on the core package.

One wrinkle is that this breaks `mvn test`: automatic module name is only added to the packaged jar, which is not built when running tests, and then the forwarder tests are unable to find core module and fail. `mvn package` is a workaround, since it also builds jar for core, which is then used to run forwarder tests.