### PR TITLE
Add merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,13 @@ jobs:
           diff
           <(grep -v ^package src/main/java/com/timgroup/statsd/CgroupReader.java)
           <(grep -v ^package dogstatsd-http/core/src/main/java/com/datadoghq/dogstatsd/http/CgroupReader.java)
+
+  merge-gate:
+    name: Merge gate
+    runs-on: ubuntu-latest
+    needs: [test, test-jnr-exclude, test-jnr-latest, check-vendored]
+    if: always()
+    steps:
+      - name: Fail if any upstream job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: exit 1


### PR DESCRIPTION
UI for required checks only allows to select individual jobs, which we have a few. Add a single CI job that joins the status of the rest, and which can be designated as the required check in the UI.