### PR TITLE
Bump javadoc plugin to latest version

### DIFF
--- a/dogstatsd-http/pom.xml
+++ b/dogstatsd-http/pom.xml
@@ -142,7 +142,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
This fixes an issue where javadoc was supplying incorrect module-related options to the java compiler when processing core module, which were incompatible with --release 7, breaking the release process.
